### PR TITLE
feat: Add source:jules label for automated findings

### DIFF
--- a/labels-base.yml
+++ b/labels-base.yml
@@ -48,3 +48,8 @@
 - name: "priority:low"
   color: "0e8a16"
   description: "Nice to have"
+
+# Source Labels - Where did this issue come from?
+- name: "source:jules"
+  color: "7C3AED"
+  description: "Automated finding from Jules scan"


### PR DESCRIPTION
## Summary

Adds the `source:jules` label to labels-base.yml for tagging issues automatically created by Jules scans.

## Changes

- **labels-base.yml** — Add new Source Labels section with `source:jules` (purple #7C3AED)

## Test Plan

Label will be synced to repos on next label-sync workflow run.

---

**Related:** Pair with #? (reusable Jules workflow PR)
**Design:** [jules-codebase-scanning.md](https://github.com/lvlup-sw/ares-elite-platform/blob/main/docs/designs/2026-01-09-jules-codebase-scanning.md)