### PR TITLE
feat: add shared CI workflows for build, test, and coverage

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,8 +76,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -10,7 +10,7 @@
 #     coverage:
 #       uses: lvlup-sw/.github/.github/workflows/coverage-gate.yml@main
 #       with:
-#         coverage-threshold: 80
+#         coverage-threshold: 90
 #
 # Behavior:
 #   - Downloads coverage artifacts from the calling workflow
@@ -28,7 +28,12 @@ on:
         description: 'Minimum line coverage percent'
         required: false
         type: number
-        default: 80
+        default: 90
+      dotnet-version:
+        description: '.NET SDK version for ReportGenerator (e.g., 9.0.x, 10.0.x)'
+        required: false
+        type: string
+        default: '9.0.x'
 
 jobs:
   coverage-gate:
@@ -37,8 +42,12 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Checkout
+      - name: Checkout shared scripts
         uses: actions/checkout@v4
+        with:
+          repository: lvlup-sw/.github
+          sparse-checkout: scripts/ci
+          path: .shared
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
@@ -49,7 +58,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Install ReportGenerator
         run: dotnet tool install -g dotnet-reportgenerator-globaltool
@@ -61,22 +70,17 @@ jobs:
             -targetdir:"./coverage-merged" \
             -reporttypes:"Cobertura;TextSummary"
 
-      - name: Download coverage gate script
-        run: |
-          curl -sL https://raw.githubusercontent.com/lvlup-sw/.github/main/scripts/ci/coverage-gate.sh \
-            -o ./coverage-gate.sh
-          chmod +x ./coverage-gate.sh
-
       - name: Run coverage gate
         id: coverage
         run: |
-          ./coverage-gate.sh \
+          chmod +x .shared/scripts/ci/coverage-gate.sh
+          .shared/scripts/ci/coverage-gate.sh \
             --coverage-file ./coverage-merged/Cobertura.xml \
             --threshold ${{ inputs.coverage-threshold }} \
             --output-dir ./coverage-merged
 
       - name: Post PR comment
-        if: always()
+        if: always() && github.event.pull_request.number
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/update-baseline.yml
+++ b/.github/workflows/update-baseline.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: 'ubuntu-latest'
+      dotnet-version:
+        description: '.NET SDK version for ReportGenerator (e.g., 9.0.x, 10.0.x)'
+        required: false
+        type: string
+        default: '9.0.x'
 
 jobs:
   update-baseline:
@@ -37,7 +42,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Install ReportGenerator
         run: dotnet tool install -g dotnet-reportgenerator-globaltool
@@ -49,6 +54,8 @@ jobs:
             -targetdir:"./coverage-merged" \
             -reporttypes:"JsonSummary"
 
+      # TODO: Wire up baseline consumption in coverage-gate.yml for diff comparisons
+      # See: coverage-gate.sh --baseline flag (currently unimplemented)
       - name: Cache baseline coverage
         uses: actions/cache/save@v4
         with:

--- a/scripts/ci/coverage-gate.sh
+++ b/scripts/ci/coverage-gate.sh
@@ -9,7 +9,7 @@
 #
 # Options:
 #   --coverage-file <path>   Path to merged cobertura XML (default: ./coverage-merged/Cobertura.xml)
-#   --threshold <percent>    Minimum line coverage required (default: 80)
+#   --threshold <percent>    Minimum line coverage required (default: 90, or COVERAGE_THRESHOLD env var)
 #   --output-dir <path>      Directory for generated files (default: ./coverage-merged)
 #   --baseline <path>        Optional baseline JSON for diff calculation
 #
@@ -187,8 +187,11 @@ EOF
 # Main entry point (only runs when script is executed directly, not sourced)
 main() {
   local coverage_file="./coverage-merged/Cobertura.xml"
-  local threshold=80
+  # Defaults align with org policy; override via env vars if needed
+  local threshold="${COVERAGE_THRESHOLD:-90}"
+  local branch_threshold="${BRANCH_COVERAGE_THRESHOLD:-70}"
   local output_dir="./coverage-merged"
+  # TODO: implement baseline diff handling for coverage gating (compare current vs cached baseline)
   local baseline=""
 
   # Parse arguments


### PR DESCRIPTION
## Summary

Extracts reusable CI workflows from per-repo duplication into centralized shared workflows. Three .NET repos (basileus, agentic-workflow, bifrost) currently copy-paste build/test/coverage logic — this PR creates shared workflows they can call with repo-specific parameters.

## Changes

- **build-and-test.yml** — Reusable workflow for checkout, build, test loop with coverage, report merge, and artifact upload. Accepts 7 inputs for repo-specific configuration.
- **coverage-gate.yml** — Reusable workflow for coverage threshold enforcement and PR comment posting. Downloads centralized coverage-gate.sh at runtime.
- **update-baseline.yml** — Reusable workflow for caching coverage baseline on main merges using SHA-keyed cache.
- **scripts/ci/coverage-gate.sh** — Centralized coverage gate script (single source of truth, previously duplicated across repos).

## Test Plan

YAML validated with Python yaml parser. Consuming repo (basileus) will test end-to-end in a follow-up PR after this merges.

---

**Design:** [shared-ci-workflows.md](https://github.com/lvlup-sw/basileus/blob/main/docs/designs/2026-02-07-shared-ci-workflows.md)
**Related:** Phase 1 of shared CI workflow migration