### PR TITLE
chore: add Graphite as bypass actor for merge queue support

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -28,6 +28,11 @@
     {
       "actor_type": "OrganizationAdmin",
       "bypass_mode": "always"
+    },
+    {
+      "actor_id": 108545121,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the Graphite GitHub App (installation ID `108545121`) as a bypass actor in the main-protection ruleset. This allows Graphite's merge queue to merge stacked PRs without being blocked by the pull request requirement.

## Changes

- **rulesets/default.json** — Added `graphite-app` Integration to `bypass_actors` with `bypass_mode: "always"`

## Test Plan

Verify in Graphite UI that merge queue can now process stacked PRs on repos using this shared ruleset.