### PR TITLE
chore: pin axiom @ 0.3.0 in marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,10 +35,10 @@
       "source": {
         "source": "npm",
         "package": "@lvlup-sw/axiom",
-        "version": "0.2.7"
+        "version": "0.3.0"
       },
-      "description": "Six skills that audit, critique, harden, and simplify backend code",
-      "version": "0.2.7",
+      "description": "Nine skills that audit, critique, harden, distill, verify, humanize, and design-constrain backend code",
+      "version": "0.3.0",
       "author": {
         "name": "LevelUp Software"
       },


### PR DESCRIPTION
## Summary

Pins `axiom` to `0.3.0` in `marketplace.json` and refreshes the description to reflect the v0.3.0 design-mode pairing release.

## Changes

| Field | Before | After |
|---|---|---|
| `plugins[1].source.version` | `0.2.7` | `0.3.0` |
| `plugins[1].version` | `0.2.7` | `0.3.0` |
| `plugins[1].description` | "Six skills that audit, critique, harden, and simplify backend code" | "Nine skills that audit, critique, harden, distill, verify, humanize, and design-constrain backend code" |

The skill count was already understated at six (we had seven user-invokable skills before this release). v0.3.0 adds two more (`axiom:design`, `axiom:scaffold-invariants`) bringing the count to nine. Description rewrite is intentional; if you'd prefer to keep the existing wording and only bump the version pins, push a fixup commit.

## Provenance

- Source PR: lvlup-sw/axiom#3 (merged)
- npm: [`@lvlup-sw/axiom@0.3.0`](https://www.npmjs.com/package/@lvlup-sw/axiom/v/0.3.0)
- GitHub Release: [`v0.3.0`](https://github.com/lvlup-sw/axiom/releases/tag/v0.3.0)

## Test plan

- [ ] JSON parses (no schema for marketplace.json to validate against beyond well-formedness)
- [ ] `claude plugin install lvlup-sw/axiom` resolves `0.3.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)