### PR TITLE
fix(runners): bump Actions runner 2.332.0 → 2.334.0 (deprecated, blocking all self-hosted CI)

### DIFF
--- a/infra/runners/Dockerfile
+++ b/infra/runners/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0-preview
 
 # GitHub Actions runner
-ARG RUNNER_VERSION=2.332.0
+ARG RUNNER_VERSION=2.334.0
 RUN mkdir -p /opt/runner \
     && curl -fsSL https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz \
     | tar xz -C /opt/runner


### PR DESCRIPTION
## Problem

All `runs-on: self-hosted` jobs across the org (e.g. strategos `pack-verify` / `coverage-gate`, plus basileus/exarchos/etc.) have been stuck **queued** and eventually auto-cancelled.

**Root cause:** the runner image bakes in `ARG RUNNER_VERSION=2.332.0`, which GitHub has now deprecated. Ephemeral runners from the Container Apps Job `caj-github-runner-dev` register fine, then fail at the listener with:

```
runner version: '2.332.0'
error occured: Runner version v2.332.0 is deprecated and cannot receive messages.
listener exit with terminated error, stop the service, no retry needed.
```

Each runner exits in ~36s without claiming a job → queued jobs never run.

## Deadlock

`deploy-runner-image.yml` is itself `runs-on: self-hosted`, so it can't rebuild the image to fix itself. The working `latest` image was therefore rebuilt **out-of-band** via `az acr build` (ACR Tasks, server-side) against `crbasileusrundev`, tagged `latest` + `runner-2.334.0`. This PR aligns the Dockerfile source of truth so the next IaC/Renovate build doesn't regress to 2.332.0.

## Change

`infra/runners/Dockerfile`: `RUNNER_VERSION` 2.332.0 → **2.334.0** (current latest; 2.333.1 also valid).

## Follow-up worth considering
- The deploy workflow's self-hosted dependency makes this a recurring footgun. Consider running `deploy-runner-image.yml` on a Blacksmith/GitHub-hosted runner so runner-image fixes can't be blocked by broken runners.
- Renovate has a regex manager for `ARG RUNNER_VERSION` — confirm it's opening these bumps promptly (this one slipped to deprecation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)