### PR TITLE
feat(ci): pin org CI for v1 release + parity/rollback docs (T13/T14)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Dependabot — GitHub Actions pin updates  (org CI re-architecture, T13 / DR-6)
+# =============================================================================
+# Dependabot owns version/SHA bumps for every `uses:` ref in this repo:
+#   - the reusable workflows under .github/workflows/
+#   - the composite actions under actions/* (their own external `uses:` steps)
+#   - the internal lvlup-sw/.github/actions/...@<sha> self-pins added in T13
+#     (Dependabot re-pins these to the v1 tag's commit once v1 is cut).
+#
+# Renovate's github-actions manager is DISABLED in renovate.json so the two
+# bots never open competing PRs for the same refs. Renovate still owns
+# everything else it already managed (the runner Dockerfile image versions,
+# lock-file maintenance, etc.).
+# =============================================================================
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # "/" scans .github/workflows/*.yml; the globbed dirs scan each composite
+    # action's action.yml (Dependabot does not auto-discover subdir actions).
+    directories:
+      - "/"
+      - "/actions/*"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    commit-message:
+      prefix: "ci"
+    # One grouped PR per run keeps action-bump noise low.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@
 # Usage:
 #   jobs:
 #     test:
-#       uses: lvlup-sw/.github/.github/workflows/build-and-test.yml@main
+#       uses: lvlup-sw/.github/.github/workflows/build-and-test.yml@v1
 #       with:
 #         solution-path: 'MyProject.slnx'
 #         test-project-patterns: |
@@ -87,11 +87,13 @@ jobs:
       # All build/test/coverage logic lives in the dotnet-build-test composite
       # action (single source of truth, DR-3). This workflow is a thin preset
       # wrapper over it. The action is referenced by its full org-repo path so
-      # GitHub resolves it without a manual checkout; @main is replaced with the
-      # release tag/SHA when the org cuts a version (DR-6).
+      # GitHub resolves it without a manual checkout. Pinned to the merged
+      # composite-layer SHA (PR #13) rather than @main so a consumer pinning
+      # this workflow @v1 gets a fully SHA-pinned action graph (DR-6 / T13).
+      # Dependabot (.github/dependabot.yml) keeps this pin current.
       - name: Build & test
         id: build-test
-        uses: lvlup-sw/.github/actions/dotnet-build-test@main
+        uses: lvlup-sw/.github/actions/dotnet-build-test@1f1e883bc1a19140206b5da7442864905c05dec8 # v1
         with:
           solution-path: ${{ inputs.solution-path }}
           test-project-patterns: ${{ inputs.test-project-patterns }}

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -15,7 +15,7 @@
 # Usage:
 #   jobs:
 #     coverage:
-#       uses: lvlup-sw/.github/.github/workflows/coverage-gate.yml@main
+#       uses: lvlup-sw/.github/.github/workflows/coverage-gate.yml@v1
 #       with:
 #         coverage-threshold: 90
 #
@@ -87,8 +87,11 @@ jobs:
             -targetdir:"./coverage-merged" \
             -reporttypes:"Cobertura;TextSummary"
 
+      # Pinned to the merged composite-layer SHA (PR #13), not @main, so a
+      # consumer pinning this workflow @v1 gets a fully SHA-pinned action graph
+      # (DR-6 / T13). Dependabot (.github/dependabot.yml) keeps this pin current.
       - name: Coverage gate
-        uses: lvlup-sw/.github/actions/coverage-gate@main
+        uses: lvlup-sw/.github/actions/coverage-gate@1f1e883bc1a19140206b5da7442864905c05dec8 # v1
         with:
           threshold: ${{ inputs.coverage-threshold }}
           gate-mode: ${{ inputs.gate-mode }}
@@ -96,4 +99,8 @@ jobs:
           coverage-file: ./coverage-merged/Cobertura.xml
           report-dir: ./coverage-reports
           output-dir: ./coverage-merged
+          # Pin the shared scripts/ci checkout to the same release SHA as the
+          # action above, so the GATE SCRIPT is pinned too — not just the action
+          # (it otherwise defaults to @main and would float; DR-6 / T13).
+          shared-ref: 1f1e883bc1a19140206b5da7442864905c05dec8 # v1
           github-token: ${{ github.token }}

--- a/actions/aot-smoke/action.yml
+++ b/actions/aot-smoke/action.yml
@@ -23,7 +23,7 @@
 #     with:
 #       dotnet-version: '10.0.x'
 #       dotnet-quality: 'preview'
-#   - uses: lvlup-sw/.github/actions/aot-smoke@<sha>
+#   - uses: lvlup-sw/.github/actions/aot-smoke@v1   # or a 40-char @<sha> (see docs/guides/org-ci-consumer-guide.md)
 #     with:
 #       project-path: samples/Bifrost.Scheduling.AotSmoke/Bifrost.Scheduling.AotSmoke.csproj
 # =============================================================================

--- a/actions/benchmark-smoke/action.yml
+++ b/actions/benchmark-smoke/action.yml
@@ -22,7 +22,7 @@
 #     with:
 #       dotnet-version: '10.0.x'
 #       dotnet-quality: 'preview'
-#   - uses: lvlup-sw/.github/actions/benchmark-smoke@<sha>
+#   - uses: lvlup-sw/.github/actions/benchmark-smoke@v1   # or a 40-char @<sha> (see docs/guides/org-ci-consumer-guide.md)
 #     with:
 #       benchmark-project: src/Bifrost.Benchmarks/Bifrost.Benchmarks.csproj
 # =============================================================================

--- a/docs/guides/org-ci-consumer-guide.md
+++ b/docs/guides/org-ci-consumer-guide.md
@@ -1,0 +1,154 @@
+# Org CI: Consumer Pinning & Migration Guide
+
+**Applies to:** `lvlup-sw/.github` composite CI layer, `v1` and later.
+**Design / plan:** `docs/designs/2026-06-15-org-ci-rearchitecture.md`,
+`docs/plans/2026-06-15-org-ci-rearchitecture.md`.
+
+The org now ships CI as **composable building blocks**: four composite actions
+plus two thin preset reusable workflows built on top of them. This guide is for
+repos that consume them — how to pin a version, which building block to use, and
+how to opt into the stricter coverage gate.
+
+For the safe-bump and revert procedure, see
+`docs/runbooks/org-ci-parity-and-rollback.md`.
+
+## What's available at `v1`
+
+| Building block | Path | Use it when |
+|----------------|------|-------------|
+| `build-and-test.yml` (reusable workflow) | `.github/workflows/build-and-test.yml` | Turnkey: restore → build → MTP test → merge coverage → upload `coverage-reports`. |
+| `coverage-gate.yml` (reusable workflow) | `.github/workflows/coverage-gate.yml` | Turnkey: download `coverage-reports`, enforce a threshold, post the PR comment. |
+| `dotnet-build-test` (composite action) | `actions/dotnet-build-test` | Compose build/test into your own job, interleaving extra steps. |
+| `coverage-gate` (composite action) | `actions/coverage-gate` | Run the shared gate script with full control over mode/metrics. |
+| `aot-smoke` (composite action, opt-in) | `actions/aot-smoke` | NativeAOT publish-and-run smoke. |
+| `benchmark-smoke` (composite action, opt-in) | `actions/benchmark-smoke` | BenchmarkDotNet `--job Dry` smoke. |
+
+**Workflow vs action:** use a **reusable workflow** when the org-standard job is
+all you need (one `uses:` line). Use the **composite actions** when you need to
+add your own steps *around* the standard ones — the GitHub reusable-workflow
+model cannot accept caller-injected steps, which is the whole reason the actions
+exist. Composite actions also can't declare `matrix` / `services` / job-level
+`permissions`; those stay in your caller workflow.
+
+## Pinning
+
+Pin every org `uses:` to an **immutable ref**. Two options:
+
+- **`@v1` (tag)** — human-readable, friendly with the bump bot. Recommended for
+  most repos.
+- **`@<40-char SHA>` (commit)** — strongest supply-chain guarantee (a tag can be
+  moved; a SHA cannot). Recommended for security-sensitive repos.
+
+Both resolve to the same release. **Never pin `@main`** — it floats and defeats
+reproducibility.
+
+```yaml
+# Reusable workflow — pin the workflow file:
+jobs:
+  test:
+    uses: lvlup-sw/.github/.github/workflows/build-and-test.yml@v1
+    with:
+      solution-path: MyProject.slnx
+      test-project-patterns: |
+        **/tests/**/*.Tests.csproj
+
+  coverage:
+    needs: test
+    uses: lvlup-sw/.github/.github/workflows/coverage-gate.yml@v1
+    with:
+      coverage-threshold: 90
+```
+
+```yaml
+# Composite action — pin the action:
+steps:
+  - uses: actions/checkout@v4
+  - uses: lvlup-sw/.github/actions/dotnet-build-test@v1
+    with:
+      solution-path: MyProject.slnx
+      test-project-patterns: |
+        **/tests/**/*.Tests.csproj
+```
+
+### Pinning the shared gate script
+
+The `coverage-gate` **action** sparse-checks-out the shared
+`scripts/ci/coverage-gate.sh` at its `shared-ref` input (default `main`). The
+`coverage-gate.yml` **workflow** pins `shared-ref` to the release for you, so
+workflow consumers get a fully pinned graph automatically.
+
+If you compose the `coverage-gate` **action directly**, pin `shared-ref` to the
+same ref as the action — otherwise the script floats on `main`:
+
+```yaml
+  - uses: lvlup-sw/.github/actions/coverage-gate@v1
+    with:
+      threshold: 80
+      gate-mode: per-assembly
+      shared-ref: v1   # pin the script too
+```
+
+### Staying current
+
+Action pins in **this org repo** are bumped by **Dependabot**
+(`.github/dependabot.yml`). In **your** repo, add a `github-actions` Dependabot
+(or Renovate) entry so your pins to `@v1`/`@<sha>` get update PRs as the org cuts
+new releases. Don't run both bots against the same `uses:` refs.
+
+## Coverage gate: defaults and opt-in
+
+The gate's **default is unchanged** from the pre-refactor org script:
+`gate-mode: aggregate`, `metrics: line`. Existing consumers
+(strategos / basileus / DataFerry) pin `@v1` and get **byte-identical** behavior
+— no input changes needed. (This is locked by a backward-compat parity test on
+the shared script and the default-parity canary; see the runbook.)
+
+Opt into stricter gating per repo:
+
+| Input | Values | Effect |
+|-------|--------|--------|
+| `gate-mode` | `aggregate` (default), `per-project`, `per-assembly` | Granularity the threshold is applied at. |
+| `metrics` | `line` (default), `line+branch` | Aggregate mode: also gate branch coverage. |
+| `exclude` | whitespace-separated globs | Skip named projects / assemblies. |
+
+```yaml
+# bifrost-style strict gate: every assembly ≥ 80% line AND branch
+  coverage:
+    uses: lvlup-sw/.github/.github/workflows/coverage-gate.yml@v1
+    with:
+      coverage-threshold: 80
+      gate-mode: per-assembly
+      metrics: line+branch
+```
+
+Failure modes are non-vacuous: an empty or fully-excluded unit set exits
+non-zero rather than passing silently.
+
+## Opt-in smoke actions
+
+Both are **no-ops by omission** — a repo that never references them is
+unaffected.
+
+```yaml
+  - uses: lvlup-sw/.github/actions/aot-smoke@v1
+    with:
+      project-path: samples/MyApp.AotSmoke/MyApp.AotSmoke.csproj
+
+  - uses: lvlup-sw/.github/actions/benchmark-smoke@v1
+    with:
+      benchmark-project: src/MyApp.Benchmarks/MyApp.Benchmarks.csproj
+```
+
+## Migration paths by repo
+
+- **Already on the org workflows** (strategos, basileus, DataFerry): change the
+  ref from `@main`/`@<old-sha>` to `@v1`. No input or behavior change. Confirm
+  via the parity runbook before merging.
+- **Forked the gate script** (valkyrie): delete the local
+  `scripts/ci/coverage-gate.sh` fork and call the `coverage-gate` action (or
+  workflow) instead. Pick `gate-mode`/`metrics` to match your fork's behavior.
+- **Hand-rolled C# CI** (authscript, ares-elite-platform, Ecs.CSharp.Benchmark):
+  replace bespoke build/test/coverage steps with `dotnet-build-test` +
+  `coverage-gate`; add `aot-smoke` / `benchmark-smoke` only if you need them.
+- **Reference consumer** (bifrost): see `lvlup-sw/bifrost#39` — composes all four
+  actions including the per-assembly + branch gate.

--- a/docs/runbooks/org-ci-parity-and-rollback.md
+++ b/docs/runbooks/org-ci-parity-and-rollback.md
@@ -1,0 +1,83 @@
+# Runbook — Org CI parity guard & rollback
+
+The safe-bump and revert procedure for consumers of the composable CI layer
+(`build-and-test.yml` / `coverage-gate.yml` and the actions under `actions/`).
+Satisfies **DR-6 / T14**: prove an existing consumer's gate behavior is unchanged
+*before* a version bump reaches it, and keep a tested one-step revert.
+
+Consumer guide: `docs/guides/org-ci-consumer-guide.md`.
+Design: `docs/designs/2026-06-15-org-ci-rearchitecture.md`.
+
+## The contract being protected
+
+Existing consumers — **strategos, basileus, DataFerry** — ran the pre-refactor
+`coverage-gate.yml` at its defaults (`gate-mode: aggregate`, `metrics: line`).
+The refactor's load-bearing promise is that **default-input behavior is
+byte-identical** to that old script: same pass/fail verdict, same PR comment.
+A version bump must not silently shift the gate.
+
+## What already guards parity inside this repo
+
+These run on every PR to `lvlup-sw/.github` and gate the release itself:
+
+1. **Byte-identical script lock** — `scripts/ci/coverage-gate.test.sh` runs the
+   new `coverage-gate.sh` and the **frozen** pre-refactor copy
+   (`scripts/ci/testdata/coverage-gate.baseline.sh`) over the same fixtures and
+   asserts identical exit code **and** byte-identical `pr-comment.md`
+   (`assert_parity`). 28/28 cases pass.
+2. **Default-parity canary** — `.github/workflows/canary-coverage-gate.yml`, job
+   `default-parity`: runs the `coverage-gate` action at default inputs
+   (aggregate/line @ 90) against a ≥90% fixture and asserts PASS + comment. The
+   companion `per-assembly-failure` job proves the opt-in strict mode fails a
+   seeded sub-threshold assembly.
+
+Together these prove the *building blocks* are parity-safe. The step below is the
+**consumer-level confirmation** the design calls for — run per consumer, per bump.
+
+## Parity gate: before bumping a consumer to `@v1`
+
+Run this on the consumer repo (example: `strategos`) before merging a bump of
+its org pin from the old ref to `@v1`. It is a manual gate; gate on the diff
+being **empty**.
+
+1. On a throwaway branch, open a no-op PR (touch a README) so the consumer's
+   existing CI runs against its **current** pin. Capture the coverage job's
+   verdict and the posted PR-comment body. This is the baseline.
+2. On a second branch off the same base, change **only** the org ref to `@v1`
+   (no input changes). Open a PR; let the same coverage job run.
+3. Compare:
+   - **Verdict** (job pass/fail) identical.
+   - **PR comment** identical line-for-line (coverage %, per-row table, verdict).
+     Diff the two comment bodies; require zero diff.
+4. **Identical → merge the bump. Any diff → stop**, do not bump; the defaults
+   shifted and that is a release bug — file against `.github`, not the consumer.
+
+> DataFerry is frozen; bump it only if it is reactivated, using the same gate.
+
+## Rollback — revert a consumer to the previous pin
+
+Every consumer is **SHA/tag pinned**, so rollback is a one-line ref change with
+no code edit — instant and total.
+
+1. Identify the previous good ref from the consumer's git history for its
+   workflow file (the SHA/tag in `uses:` before the bump).
+2. Repin:
+   ```yaml
+   # revert: was @v1
+   uses: lvlup-sw/.github/.github/workflows/coverage-gate.yml@<previous-sha>
+   ```
+   If the consumer **composes the `coverage-gate` action directly**, also revert
+   its `shared-ref` to the previous ref — otherwise the gate script stays on the
+   newer version.
+3. Open/merge the one-line revert PR. CI now runs the previous layer; confirm the
+   coverage job reproduces the pre-bump verdict + comment (same comparison as the
+   parity gate above).
+4. Reopen the `.github` issue for the regression and re-pin forward only after
+   the parity gate passes again.
+
+### Status
+
+No consumer is pinned to `@v1` yet, so there is nothing live to roll back *from*
+today; this is the ready-to-run procedure. It gets its first real exercise at the
+first consumer bump (bifrost via `bifrost#39`, then strategos/basileus), which is
+the natural and honest place to validate it end-to-end.

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "GitHub Actions pins are owned by Dependabot (.github/dependabot.yml) since the org CI re-architecture (T13/DR-6); Renovate's github-actions manager is disabled below so the two bots do not open competing PRs. Renovate keeps the runner Dockerfile image versions and lock-file maintenance.",
   "extends": [
     "config:recommended"
   ],
+  "github-actions": {
+    "enabled": false
+  },
   "schedule": [
     "on saturday",
     "on sunday"


### PR DESCRIPTION
## Post-merge follow-ups for the org CI re-architecture (T13 + T14)

Closes the in-repo half of **#12** (DR-6). Builds on the merged composite layer
(#13). T15 issue-filing and the `v1` tag are handled out-of-band after this lands.

### T13 — release pinning + version management
- **Pin internal refs to SHA.** The two reusable workflows referenced their
  composite actions via `@main`, which floats. Pinned both to the merged
  composite-layer SHA (`1f1e883`), and pinned `coverage-gate`'s `shared-ref` to
  the same SHA so the **gate script** is pinned too (it otherwise sparse-checks
  out `scripts/ci` from `@main`). Net effect: a consumer pinning a workflow
  `@v1` gets a fully SHA-pinned action graph — nothing floats on `main`.
- **Dependabot owns action pins.** Added `.github/dependabot.yml` (github-actions
  ecosystem over `.github/workflows` + `actions/*`); disabled Renovate's
  github-actions manager in `renovate.json` so the two bots don't open competing
  PRs. Renovate keeps the runner Dockerfile + lock-file maintenance.
- **Consumer guide.** `docs/guides/org-ci-consumer-guide.md` — how to pin
  `@v1`/`@<sha>`, action-vs-workflow consumption, the opt-in
  `gate-mode: per-assembly` + `metrics: line+branch`, and per-cohort migration.
- Updated `@main`/`@<sha>` usage examples to `@v1`.

### T14 — backward-compat parity guard + rollback
- `docs/runbooks/org-ci-parity-and-rollback.md` — the **consumer-level** parity
  gate (run per consumer before bumping its pin to `@v1`), layered on the
  existing in-repo guards (the byte-identical script lock in
  `coverage-gate.test.sh` vs the frozen `coverage-gate.baseline.sh`, and the
  `default-parity` canary). Plus the ready-to-run **"pin to previous SHA"**
  rollback procedure. No consumer is on `v1` yet, so the first real exercise is
  the first bump (bifrost via bifrost#39).

### Notes
- Internal refs pin to `1f1e883` (PR #13's merge commit) with a `# v1` comment;
  `v1` will be tagged at **this** PR's merge commit (a child of `1f1e883` whose
  action/script code is byte-identical). Dependabot reconciles the pin to the
  tagged commit on its next run.
- `format-check.yml` / `update-baseline.yml` / `label-sync.yml` are intentionally
  left on the `@main` example convention — not rebuilt on composite actions this
  round (deferred, same pattern later).

### Verification
- `actionlint` clean on both edited workflows.
- `renovate.json` / `dependabot.yml` parse.
- `scripts/ci/coverage-gate.test.sh` 28/28 (unchanged; no script edits here).
- The coverage-gate + smoke + build-test canaries run on this PR.

Refs #12
