### PR TITLE
feat(ci): TypeScript composable CI layer — node-build-test + canary (T1-T9)

### DIFF
--- a/.github/workflows/canary-node-ci.yml
+++ b/.github/workflows/canary-node-ci.yml
@@ -20,6 +20,7 @@ on:
     paths:
       - 'actions/node-build-test/**'
       - 'actions/node-benchmark-smoke/**'
+      - 'actions/coverage-gate/**'
       - '.github/workflows/node-build-test.yml'
       - '.github/workflows/canary-node-ci.yml'
       - 'scripts/ci/merge-cobertura.mjs'

--- a/.github/workflows/canary-node-ci.yml
+++ b/.github/workflows/canary-node-ci.yml
@@ -1,0 +1,134 @@
+# =============================================================================
+# Canary: Node composable CI layer (DR-T4 / task-8)
+# =============================================================================
+# Exercises the new TS actions against the committed fixture project in
+# scripts/ci/testdata/ts-canary-fixture on PRs to THIS repo, proving:
+#   (a) node-build-test produces a merged Cobertura and the language-agnostic
+#       coverage-gate PASSES it at a low threshold and FAILS it at 100;
+#   (b) node-benchmark-smoke runs (`vitest bench`);
+#   (c) the lockfile -> package-manager auto-detect rule is correct.
+# A caller that omits node-benchmark-smoke (job a) is unaffected — no-op by omission.
+#
+# Local actions are referenced via ./actions/... and shared-ref is pinned to the
+# PR commit (github.sha) so the canary exercises THIS PR's merge helper, not main.
+# =============================================================================
+
+name: Canary - Node CI
+
+on:
+  pull_request:
+    paths:
+      - 'actions/node-build-test/**'
+      - 'actions/node-benchmark-smoke/**'
+      - '.github/workflows/node-build-test.yml'
+      - '.github/workflows/canary-node-ci.yml'
+      - 'scripts/ci/merge-cobertura.mjs'
+      - 'scripts/ci/testdata/ts-canary-fixture/**'
+
+permissions:
+  contents: read
+
+env:
+  FIXTURE: scripts/ci/testdata/ts-canary-fixture
+
+jobs:
+  # (a) Build+test produces a merged Cobertura; the gate passes low / fails at 100.
+  build-test-and-gate:
+    name: node-build-test + coverage-gate (pass low / fail 100)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (provides the local actions + fixture)
+        uses: actions/checkout@v4
+
+      - name: Build & test the fixture
+        id: bt
+        uses: ./actions/node-build-test
+        with:
+          working-directory: ${{ env.FIXTURE }}
+          shared-ref: ${{ github.sha }}
+
+      - name: Assert tests passed and a merged report exists
+        env:
+          TESTS_PASSED: ${{ steps.bt.outputs.tests-passed }}
+        run: |
+          set -euo pipefail
+          if [ "$TESTS_PASSED" != "true" ]; then
+            echo "::error::node-build-test reported tests-passed=$TESTS_PASSED"
+            exit 1
+          fi
+          test -f ./coverage-reports/Cobertura.xml || {
+            echo "::error::merged Cobertura.xml was not produced"; exit 1; }
+          echo "node-build-test produced coverage-reports/Cobertura.xml"
+
+      - name: Gate PASSES at a low threshold
+        id: gate_pass
+        uses: ./actions/coverage-gate
+        with:
+          threshold: '1'
+          coverage-file: ./coverage-reports/Cobertura.xml
+          output-dir: ./coverage-merged
+          shared-ref: ${{ github.sha }}
+
+      - name: Gate FAILS at threshold 100 (fixture is <100% covered)
+        id: gate_fail
+        continue-on-error: true
+        uses: ./actions/coverage-gate
+        with:
+          threshold: '100'
+          coverage-file: ./coverage-reports/Cobertura.xml
+          output-dir: ./coverage-merged-100
+          shared-ref: ${{ github.sha }}
+
+      - name: Assert verdicts
+        env:
+          PASS_OUTCOME: ${{ steps.gate_pass.outcome }}
+          FAIL_OUTCOME: ${{ steps.gate_fail.outcome }}
+        run: |
+          set -euo pipefail
+          [ "$PASS_OUTCOME" = "success" ] || { echo "::error::gate@1 should pass, got $PASS_OUTCOME"; exit 1; }
+          [ "$FAIL_OUTCOME" = "failure" ] || { echo "::error::gate@100 should fail, got $FAIL_OUTCOME"; exit 1; }
+          echo "Canary OK: TS coverage gated by the language-agnostic coverage-gate."
+
+  # (b) Opt-in benchmark smoke runs.
+  benchmark-smoke:
+    name: node-benchmark-smoke (vitest bench)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run benchmark smoke
+        uses: ./actions/node-benchmark-smoke
+        with:
+          working-directory: ${{ env.FIXTURE }}
+
+  # (c) Lockfile -> package-manager auto-detect rule (cheap; no installs).
+  pm-detect:
+    name: PM auto-detect (${{ matrix.pm }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pm: npm
+            lockfile: package-lock.json
+          - pm: pnpm
+            lockfile: pnpm-lock.yaml
+          - pm: bun
+            lockfile: bun.lockb
+    steps:
+      - name: Detect from a lockfile fixture
+        env:
+          LOCKFILE: ${{ matrix.lockfile }}
+          EXPECTED: ${{ matrix.pm }}
+        run: |
+          set -euo pipefail
+          d="$(mktemp -d)"
+          cd "$d"
+          touch "$LOCKFILE"
+          # Mirrors the detection rule in actions/node-build-test/action.yml.
+          if [[ -f bun.lockb || -f bun.lock ]]; then pm=bun
+          elif [[ -f pnpm-lock.yaml ]]; then pm=pnpm
+          else pm=npm; fi
+          echo "$LOCKFILE -> $pm (expected $EXPECTED)"
+          [[ "$pm" == "$EXPECTED" ]]

--- a/.github/workflows/node-build-test.yml
+++ b/.github/workflows/node-build-test.yml
@@ -36,6 +36,16 @@ on:
         required: false
         type: string
         default: 'auto'
+      install-command:
+        description: 'Override the install command. Empty = derived from the detected PM.'
+        required: false
+        type: string
+        default: ''
+      shared-ref:
+        description: 'Ref of lvlup-sw/.github to sparse-checkout scripts/ci (the merge helper) from. Repinned to the release SHA at release.'
+        required: false
+        type: string
+        default: 'main'
       test-command:
         description: 'Test command (coverage flags appended by the action).'
         required: false
@@ -86,7 +96,9 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
           node-version: ${{ inputs.node-version }}
           package-manager: ${{ inputs.package-manager }}
+          install-command: ${{ inputs.install-command }}
           test-command: ${{ inputs.test-command }}
           lint-command: ${{ inputs.lint-command }}
           typecheck: ${{ inputs.typecheck }}
           coverage-provider: ${{ inputs.coverage-provider }}
+          shared-ref: ${{ inputs.shared-ref }}

--- a/.github/workflows/node-build-test.yml
+++ b/.github/workflows/node-build-test.yml
@@ -1,0 +1,92 @@
+# =============================================================================
+# Reusable Workflow: Node Build & Test with Coverage  (TS parity, DR-T4)
+# =============================================================================
+# Thin PRESET over the `node-build-test` composite action — the TypeScript
+# counterpart to build-and-test.yml. Installs, typechecks, optionally lints, runs
+# vitest with coverage, emits one merged Cobertura, and uploads `coverage-reports`.
+# Gate it with the language-agnostic `coverage-gate` action on the produced report
+# (TS consumes the gate ACTION directly — no .NET ReportGenerator merge step).
+#
+# Usage:
+#   jobs:
+#     build-test:
+#       uses: lvlup-sw/.github/.github/workflows/node-build-test.yml@v1.1
+#       with:
+#         working-directory: .
+#         lint-command: 'eslint .'   # opt-in
+# =============================================================================
+
+name: Node Build & Test
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Directory to run in (the package/workspace root).'
+        required: false
+        type: string
+        default: '.'
+      node-version:
+        description: 'Node.js version.'
+        required: false
+        type: string
+        default: 'lts/*'
+      package-manager:
+        description: 'auto | npm | pnpm | bun.'
+        required: false
+        type: string
+        default: 'auto'
+      test-command:
+        description: 'Test command (coverage flags appended by the action).'
+        required: false
+        type: string
+        default: 'vitest run'
+      lint-command:
+        description: 'Opt-in lint command; skipped when empty.'
+        required: false
+        type: string
+        default: ''
+      typecheck:
+        description: 'Run tsc --noEmit before tests.'
+        required: false
+        type: boolean
+        default: true
+      coverage-provider:
+        description: 'vitest coverage provider: v8 or istanbul.'
+        required: false
+        type: string
+        default: 'v8'
+      runner:
+        description: 'GitHub Actions runner label.'
+        required: false
+        type: string
+        default: 'self-hosted'
+    outputs:
+      tests-passed:
+        description: 'Whether the test run passed.'
+        value: ${{ jobs.build-test.outputs.tests-passed }}
+
+jobs:
+  build-test:
+    name: Node Build & Test
+    runs-on: ${{ inputs.runner }}
+    outputs:
+      tests-passed: ${{ steps.build-test.outputs.tests-passed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Internal action ref is @main here and is repinned to the v1.1 release SHA
+      # at the release step (DR-T4 / T10), mirroring how v1's refs were pinned in
+      # the follow-up release PR (#14). Dependabot then keeps the pin current.
+      - name: Build & test
+        id: build-test
+        uses: lvlup-sw/.github/actions/node-build-test@main
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          node-version: ${{ inputs.node-version }}
+          package-manager: ${{ inputs.package-manager }}
+          test-command: ${{ inputs.test-command }}
+          lint-command: ${{ inputs.lint-command }}
+          typecheck: ${{ inputs.typecheck }}
+          coverage-provider: ${{ inputs.coverage-provider }}

--- a/actions/node-benchmark-smoke/action.yml
+++ b/actions/node-benchmark-smoke/action.yml
@@ -50,6 +50,10 @@ runs:
           elif [[ -f pnpm-lock.yaml ]]; then pm=pnpm
           else pm=npm; fi
         fi
+        case "$pm" in
+          npm|pnpm|bun) ;;
+          *) echo "::error::unsupported package-manager '$pm' (expected auto|npm|pnpm|bun)"; exit 1 ;;
+        esac
         echo "pm=$pm" >> "$GITHUB_OUTPUT"
 
     - name: Setup Node

--- a/actions/node-benchmark-smoke/action.yml
+++ b/actions/node-benchmark-smoke/action.yml
@@ -1,0 +1,86 @@
+# =============================================================================
+# Composite Action: Node Benchmark Smoke (opt-in)  —  TS parity with benchmark-smoke
+# =============================================================================
+# The TypeScript counterpart to the C# `benchmark-smoke`: a fast `vitest bench`
+# run that proves the benchmarks compile and execute, without a full timed
+# measurement. OPT-IN — a repo that never `uses:` it is unaffected (no-op by
+# omission). Self-contained: detects the package manager, installs, and runs.
+#
+# Usage:
+#   - uses: lvlup-sw/.github/actions/node-benchmark-smoke@v1.1
+#     with:
+#       working-directory: servers/exarchos-mcp
+# =============================================================================
+
+name: 'Node Benchmark Smoke'
+description: 'Run `vitest bench` as a fast smoke test that benchmarks compile and execute.'
+
+inputs:
+  working-directory:
+    description: 'Directory containing the benchmark suite.'
+    required: false
+    default: '.'
+  bench-command:
+    description: 'Benchmark command to run.'
+    required: false
+    default: 'vitest bench --run'
+  node-version:
+    description: 'Node.js version for actions/setup-node.'
+    required: false
+    default: 'lts/*'
+  package-manager:
+    description: 'auto (detect from lockfile), npm, pnpm, or bun.'
+    required: false
+    default: 'auto'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Detect package manager
+      id: detect
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        PM_INPUT: ${{ inputs.package-manager }}
+      run: |
+        set -euo pipefail
+        pm="$PM_INPUT"
+        if [[ "$pm" == "auto" ]]; then
+          if [[ -f bun.lockb || -f bun.lock ]]; then pm=bun
+          elif [[ -f pnpm-lock.yaml ]]; then pm=pnpm
+          else pm=npm; fi
+        fi
+        echo "pm=$pm" >> "$GITHUB_OUTPUT"
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        PM: ${{ steps.detect.outputs.pm }}
+      run: |
+        set -euo pipefail
+        case "$PM" in
+          pnpm) corepack enable && corepack prepare pnpm@latest --activate && pnpm install --frozen-lockfile ;;
+          bun)  npm install -g bun && bun install --frozen-lockfile ;;
+          npm)  if [[ -f package-lock.json ]]; then npm ci; else npm install; fi ;;
+        esac
+
+    - name: Benchmark smoke
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        PM: ${{ steps.detect.outputs.pm }}
+        BENCH_CMD: ${{ inputs.bench-command }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC2086
+        case "$PM" in
+          npm)  npx --no-install $BENCH_CMD ;;
+          pnpm) pnpm exec $BENCH_CMD ;;
+          bun)  bunx $BENCH_CMD ;;
+        esac

--- a/actions/node-build-test/action.yml
+++ b/actions/node-build-test/action.yml
@@ -1,0 +1,208 @@
+# =============================================================================
+# Composite Action: Node Build & Test with Coverage  (TS parity with C#, DR-T1)
+# =============================================================================
+# The TypeScript counterpart to `dotnet-build-test`: install → typecheck →
+# (opt-in) lint → vitest with coverage → emit ONE merged Cobertura → upload the
+# `coverage-reports` artifact. It deliberately produces the SAME artifact
+# contract as the C# action so the language-agnostic `coverage-gate` action
+# consumes it unchanged (no TS-native gate; no .NET ReportGenerator).
+#
+# Package manager is auto-detected from the lockfile (npm / pnpm / bun); pnpm via
+# corepack and bun via `npm i -g bun`, so the action stays self-contained (only
+# actions/setup-node + actions/checkout + actions/upload-artifact, all pinned and
+# Dependabot-managed). Lint is opt-in (default off). The merged report is written
+# by the shared, unit-tested scripts/ci/merge-cobertura.mjs.
+#
+# Usage (compose with the gate in one job):
+#   - uses: actions/checkout@v4
+#   - uses: lvlup-sw/.github/actions/node-build-test@v1.1
+#     with:
+#       working-directory: .
+#   - uses: lvlup-sw/.github/actions/coverage-gate@v1.1
+#     with:
+#       coverage-file: ./coverage-reports/Cobertura.xml
+#       shared-ref: v1.1
+# =============================================================================
+
+name: 'node-build-test'
+description: >-
+  Install, typecheck, optionally lint, and run vitest with coverage for a TS/JS
+  project; emit one merged Cobertura and upload the coverage-reports artifact.
+
+inputs:
+  working-directory:
+    description: 'Directory to run in (the package/workspace root).'
+    required: false
+    default: '.'
+  node-version:
+    description: 'Node.js version for actions/setup-node.'
+    required: false
+    default: 'lts/*'
+  package-manager:
+    description: 'auto (detect from lockfile), npm, pnpm, or bun.'
+    required: false
+    default: 'auto'
+  install-command:
+    description: 'Override the install command. Empty = derived from the detected PM (frozen install).'
+    required: false
+    default: ''
+  test-command:
+    description: 'Test command (coverage flags are appended by the action). Default runs the whole suite.'
+    required: false
+    default: 'vitest run'
+  lint-command:
+    description: 'Opt-in lint command (e.g. "eslint ."); skipped when empty.'
+    required: false
+    default: ''
+  typecheck:
+    description: 'Run `tsc --noEmit` before tests (true/false).'
+    required: false
+    default: 'true'
+  coverage-provider:
+    description: 'vitest coverage provider: v8 (default) or istanbul (instrumented TSX/JSX fallback).'
+    required: false
+    default: 'v8'
+  shared-ref:
+    description: 'Ref of lvlup-sw/.github to sparse-checkout scripts/ci (the merge helper) from. Pin to a SHA/tag.'
+    required: false
+    default: 'main'
+
+outputs:
+  tests-passed:
+    description: 'Whether the test run passed.'
+    value: ${{ steps.test.outputs.tests-passed }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Detect package manager
+      id: detect
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        PM_INPUT: ${{ inputs.package-manager }}
+      run: |
+        set -euo pipefail
+        pm="$PM_INPUT"
+        if [[ "$pm" == "auto" ]]; then
+          if [[ -f bun.lockb || -f bun.lock ]]; then pm=bun
+          elif [[ -f pnpm-lock.yaml ]]; then pm=pnpm
+          else pm=npm; fi
+        fi
+        echo "pm=$pm" >> "$GITHUB_OUTPUT"
+        echo "Detected package manager: $pm"
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        PM: ${{ steps.detect.outputs.pm }}
+        INSTALL_CMD: ${{ inputs.install-command }}
+      run: |
+        set -euo pipefail
+        case "$PM" in
+          pnpm) corepack enable && corepack prepare pnpm@latest --activate ;;
+          bun)  npm install -g bun ;;
+        esac
+        if [[ -n "$INSTALL_CMD" ]]; then
+          # shellcheck disable=SC2086
+          eval "$INSTALL_CMD"
+        else
+          case "$PM" in
+            npm)  if [[ -f package-lock.json ]]; then npm ci; else npm install; fi ;;
+            pnpm) pnpm install --frozen-lockfile ;;
+            bun)  bun install --frozen-lockfile ;;
+          esac
+        fi
+
+    - name: Typecheck
+      if: ${{ inputs.typecheck == 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        PM: ${{ steps.detect.outputs.pm }}
+      run: |
+        set -euo pipefail
+        case "$PM" in
+          npm)  npx --no-install tsc --noEmit ;;
+          pnpm) pnpm exec tsc --noEmit ;;
+          bun)  bunx tsc --noEmit ;;
+        esac
+
+    - name: Lint (opt-in)
+      if: ${{ inputs.lint-command != '' }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        LINT_CMD: ${{ inputs.lint-command }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC2086
+        eval "$LINT_CMD"
+
+    - name: Test with coverage
+      id: test
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        PM: ${{ steps.detect.outputs.pm }}
+        TEST_CMD: ${{ inputs.test-command }}
+        COVERAGE_PROVIDER: ${{ inputs.coverage-provider }}
+      run: |
+        set -uo pipefail
+        cov="--coverage --coverage.provider=$COVERAGE_PROVIDER --coverage.reporter=cobertura --coverage.reporter=text-summary"
+        # shellcheck disable=SC2086
+        case "$PM" in
+          npm)  npx --no-install $TEST_CMD $cov ;;
+          pnpm) pnpm exec $TEST_CMD $cov ;;
+          bun)  bunx $TEST_CMD $cov ;;
+        esac
+        rc=$?
+        if [[ $rc -eq 0 ]]; then
+          echo "tests-passed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "tests-passed=false" >> "$GITHUB_OUTPUT"
+        fi
+        exit $rc
+
+    - name: Checkout shared CI scripts (merge helper)
+      if: always()
+      uses: actions/checkout@v4
+      with:
+        repository: lvlup-sw/.github
+        ref: ${{ inputs.shared-ref }}
+        sparse-checkout: scripts/ci
+        # Distinct from coverage-gate's `.shared` so both can run in one job.
+        path: .nbt-shared
+
+    - name: Merge coverage into one Cobertura
+      if: always()
+      shell: bash
+      env:
+        WORKDIR: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        # vitest/istanbul writes <reportsDir>/cobertura-coverage.xml (default ./coverage).
+        mapfile -t files < <(find "$WORKDIR" -path '*/node_modules' -prune -o -name 'cobertura-coverage.xml' -print)
+        if [[ ${#files[@]} -eq 0 ]]; then
+          echo "::warning::node-build-test: no cobertura-coverage.xml found under $WORKDIR"
+          exit 0
+        fi
+        mkdir -p "${GITHUB_WORKSPACE}/coverage-reports"
+        node "${GITHUB_WORKSPACE}/.nbt-shared/scripts/ci/merge-cobertura.mjs" \
+          "${files[@]}" --out "${GITHUB_WORKSPACE}/coverage-reports/Cobertura.xml"
+        echo "Merged ${#files[@]} report(s) -> coverage-reports/Cobertura.xml"
+
+    - name: Upload coverage reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-reports
+        path: coverage-reports/Cobertura.xml
+        retention-days: 7
+        if-no-files-found: warn

--- a/actions/node-build-test/action.yml
+++ b/actions/node-build-test/action.yml
@@ -89,6 +89,10 @@ runs:
           elif [[ -f pnpm-lock.yaml ]]; then pm=pnpm
           else pm=npm; fi
         fi
+        case "$pm" in
+          npm|pnpm|bun) ;;
+          *) echo "::error::unsupported package-manager '$pm' (expected auto|npm|pnpm|bun)"; exit 1 ;;
+        esac
         echo "pm=$pm" >> "$GITHUB_OUTPUT"
         echo "Detected package manager: $pm"
 

--- a/docs/guides/org-ci-consumer-guide.md
+++ b/docs/guides/org-ci-consumer-guide.md
@@ -152,3 +152,48 @@ unaffected.
   `coverage-gate`; add `aot-smoke` / `benchmark-smoke` only if you need them.
 - **Reference consumer** (bifrost): see `lvlup-sw/bifrost#39` — composes all four
   actions including the per-assembly + branch gate.
+
+## TypeScript / Node consumers (`v1.1`+)
+
+The TS layer mirrors the C# one: a `node-build-test` action (+ a
+`node-build-test.yml` preset) and an opt-in `node-benchmark-smoke`. **The gate is
+the same** — `coverage-gate` consumes the generic Cobertura `node-build-test`
+emits, so there is no TS-specific gate.
+
+```yaml
+jobs:
+  ci:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lvlup-sw/.github/actions/node-build-test@v1.1
+        with:
+          working-directory: .
+          lint-command: 'eslint .'   # opt-in; omit to skip lint
+      # Consume the gate as an ACTION on the produced report — NOT the
+      # coverage-gate.yml workflow (that merges via .NET ReportGenerator).
+      - uses: lvlup-sw/.github/actions/coverage-gate@v1.1
+        with:
+          coverage-file: ./coverage-reports/Cobertura.xml
+          threshold: 80
+          shared-ref: v1.1
+```
+
+Or turnkey via the preset (then add a gate job):
+`uses: lvlup-sw/.github/.github/workflows/node-build-test.yml@v1.1`.
+
+Notes:
+
+- **Coverage provider package required.** vitest needs `@vitest/coverage-v8`
+  (default) or `@vitest/coverage-istanbul` installed to emit Cobertura. The action
+  passes `--coverage.reporter=cobertura`; set `coverage-provider: istanbul` for the
+  instrumented TSX/JSX fallback.
+- **Package manager** is auto-detected from the lockfile (npm / pnpm / bun); set
+  `package-manager` to force it. **Lint** is opt-in (`lint-command`, default off).
+- **Monorepos:** `node-build-test` merges every project's Cobertura into one
+  `coverage-reports/Cobertura.xml` (via the shared `scripts/ci/merge-cobertura.mjs`),
+  so the `aggregate` default works across all projects.
+- **Gating granularity.** istanbul names each Cobertura `<package>` by **source
+  directory**, not assembly — so `gate-mode: per-assembly` gates **per-directory**
+  for TS (same mechanism, different unit). `--exclude` matches the directory name.
+- Pin `@v1.1`/`@<sha>` and let Dependabot bump it, same as the C# blocks.

--- a/scripts/ci/coverage-gate.test.sh
+++ b/scripts/ci/coverage-gate.test.sh
@@ -340,6 +340,42 @@ run_gate_noxmllint 1 "task-18: --per-assembly (no xmllint) all-excluded fails (n
     --per-assembly "$DATA/merged-multipackage-pass.cobertura.xml" --threshold 80 \
     --exclude 'Bifrost*'
 
+# ---------------------------------------------------------------------------
+# DR-T2 — cross-language (TypeScript / vitest+istanbul) Cobertura
+#
+# The gate is generic Cobertura: it must read a vitest/istanbul `cobertura`
+# report identically to a .NET one. The fixture uses DIRECTORY-style <package>
+# names (incl. a nested, slash-containing monorepo path) + an istanbul DOCTYPE
+# and per-line <lines> subtree. These cases RED-guard any C#-specific assumption
+# creeping into coverage-gate.sh. (Discovery finding F1 — locked under test.)
+# ---------------------------------------------------------------------------
+
+# Aggregate default (line-only): line 0.90 >= 80 -> PASS, same as any .NET report.
+run_gate 0 "DR-T2: aggregate default passes on TS/istanbul cobertura (line 0.90 >= 80)" -- \
+    --coverage-file "$DATA/ts-vitest.cobertura.xml" --threshold 80
+
+# Aggregate default at 95: line 0.90 < 95 -> FAIL.
+run_gate 1 "DR-T2: aggregate default fails on TS cobertura when line 0.90 < 95" -- \
+    --coverage-file "$DATA/ts-vitest.cobertura.xml" --threshold 95
+
+# Per-assembly (== per-DIRECTORY for TS): both dirs clear 80 line+branch -> PASS.
+# Proves the gate parses slash-containing <package> names.
+run_gate 0 "DR-T2: --per-assembly passes on TS cobertura (every directory >= 80 line+branch)" -- \
+    --per-assembly "$DATA/ts-vitest.cobertura.xml" --threshold 80
+
+# At 85, servers/exarchos-mcp/src branch 0.82 < 85 -> FAIL (one sub-threshold dir).
+run_gate 1 "DR-T2: --per-assembly fails when a TS directory branch (0.82) is below 85" -- \
+    --per-assembly "$DATA/ts-vitest.cobertura.xml" --threshold 85
+
+# Excluding the failing directory BY ITS SLASH-CONTAINING NAME flips fail -> pass.
+run_gate 0 "DR-T2: --per-assembly --exclude on a slash-containing directory name passes" -- \
+    --per-assembly "$DATA/ts-vitest.cobertura.xml" --threshold 85 \
+    --exclude 'servers/exarchos-mcp/src'
+
+# grep/sed fallback (no xmllint) yields the same verdict on directory names.
+run_gate_noxmllint 1 "DR-T2: --per-assembly (no xmllint) fails on sub-threshold TS directory" -- \
+    --per-assembly "$DATA/ts-vitest.cobertura.xml" --threshold 85
+
 echo
 echo "=== $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/ci/merge-cobertura.mjs
+++ b/scripts/ci/merge-cobertura.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Zero-dependency Cobertura merge helper (DR-T1).
+//
+// Merges N Cobertura XML reports into one, so a TS monorepo with separate
+// vitest project roots can hand the org `coverage-gate` a SINGLE merged report —
+// keeping the parity-critical `aggregate` default usable — without pulling in a
+// .NET ReportGenerator or any npm dependency.
+//
+// Strategy: the root <coverage> carries lines/branches valid+covered COUNTS, so
+// the aggregate rates are recomputed from the summed totals (exact). Per-<package>
+// rows are unioned verbatim — vitest projects cover disjoint source dirs, so their
+// package names don't collide. (istanbul Cobertura does not put counts on
+// <package>, so a same-named collision can't be re-rated; that's out of scope and
+// does not occur for disjoint roots — see docs/guides/org-ci-consumer-guide.md.)
+//
+// Library:  import { mergeCoberturaStrings } from './merge-cobertura.mjs'
+// CLI:      node merge-cobertura.mjs <a.xml> <b.xml> ... --out <merged.xml>
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+const COUNT_ATTRS = ['lines-valid', 'lines-covered', 'branches-valid', 'branches-covered']
+
+function rootTag(xml) {
+  const m = xml.match(/<coverage\b[^>]*>/)
+  if (!m) throw new Error('not a Cobertura report: no <coverage> root element')
+  return m[0]
+}
+
+function attr(tag, name) {
+  const m = tag.match(new RegExp(`\\b${name}="([^"]*)"`))
+  return m ? m[1] : undefined
+}
+
+function packageElements(xml) {
+  // Match each <package …/> (self-closing) or <package …>…</package> block.
+  return xml.match(/<package\b[^>]*?(?:\/>|>[\s\S]*?<\/package>)/g) || []
+}
+
+function rate(covered, valid) {
+  if (!valid) return 0
+  return Math.round((covered / valid) * 10000) / 10000
+}
+
+/**
+ * Merge an array of Cobertura XML strings into one Cobertura XML string.
+ * @param {string[]} xmlStrings
+ * @returns {string}
+ */
+export function mergeCoberturaStrings(xmlStrings) {
+  if (!Array.isArray(xmlStrings) || xmlStrings.length === 0) {
+    throw new Error('mergeCoberturaStrings requires a non-empty array of XML strings')
+  }
+  const totals = { 'lines-valid': 0, 'lines-covered': 0, 'branches-valid': 0, 'branches-covered': 0 }
+  const packages = []
+  for (const xml of xmlStrings) {
+    const tag = rootTag(xml)
+    for (const a of COUNT_ATTRS) totals[a] += Number(attr(tag, a) ?? 0)
+    packages.push(...packageElements(xml))
+  }
+  const lineRate = rate(totals['lines-covered'], totals['lines-valid'])
+  const branchRate = rate(totals['branches-covered'], totals['branches-valid'])
+  const indentedPackages = packages.map((p) => '    ' + p.trim()).join('\n')
+  return [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    `<coverage line-rate="${lineRate}" branch-rate="${branchRate}" ` +
+      `lines-valid="${totals['lines-valid']}" lines-covered="${totals['lines-covered']}" ` +
+      `branches-valid="${totals['branches-valid']}" branches-covered="${totals['branches-covered']}" ` +
+      'version="1.9" timestamp="0">',
+    '  <sources/>',
+    '  <packages>',
+    indentedPackages,
+    '  </packages>',
+    '</coverage>',
+    '',
+  ].filter((l) => l !== '').join('\n') + '\n'
+}
+
+// ---- CLI ----------------------------------------------------------------
+function isMain() {
+  return process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href
+}
+
+if (isMain()) {
+  const args = process.argv.slice(2)
+  const out = (() => {
+    const i = args.indexOf('--out')
+    return i >= 0 ? args[i + 1] : './coverage-merged/Cobertura.xml'
+  })()
+  const inputs = args.filter((a, i) => a !== '--out' && args[i - 1] !== '--out')
+  if (inputs.length === 0) {
+    console.error('usage: merge-cobertura.mjs <a.xml> [b.xml ...] --out <merged.xml>')
+    process.exit(2)
+  }
+  const merged = mergeCoberturaStrings(inputs.map((f) => readFileSync(f, 'utf8')))
+  mkdirSync(dirname(out), { recursive: true })
+  writeFileSync(out, merged)
+  console.error(`merged ${inputs.length} report(s) -> ${out}`)
+}

--- a/scripts/ci/merge-cobertura.mjs
+++ b/scripts/ci/merge-cobertura.mjs
@@ -85,7 +85,13 @@ if (isMain()) {
   const args = process.argv.slice(2)
   const out = (() => {
     const i = args.indexOf('--out')
-    return i >= 0 ? args[i + 1] : './coverage-merged/Cobertura.xml'
+    if (i === -1) return './coverage-merged/Cobertura.xml'
+    const v = args[i + 1]
+    if (!v || v.startsWith('--')) {
+      console.error('error: --out requires a path argument')
+      process.exit(2)
+    }
+    return v
   })()
   const inputs = args.filter((a, i) => a !== '--out' && args[i - 1] !== '--out')
   if (inputs.length === 0) {

--- a/scripts/ci/merge-cobertura.test.mjs
+++ b/scripts/ci/merge-cobertura.test.mjs
@@ -9,7 +9,11 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 import { mergeCoberturaStrings } from './merge-cobertura.mjs'
+
+const SCRIPT = fileURLToPath(new URL('./merge-cobertura.mjs', import.meta.url))
 
 const fileA = `<?xml version="1.0" ?>
 <coverage line-rate="0.9" branch-rate="0.8" lines-valid="100" lines-covered="90" branches-valid="50" branches-covered="40" version="1.9" timestamp="0">
@@ -66,4 +70,15 @@ test('emits a single well-formed <coverage> root', () => {
   assert.equal(merged.match(/<coverage[\s>]/g).length, 1)
   assert.equal(merged.match(/<\/coverage>/g).length, 1)
   assert.match(merged, /^<\?xml/)
+})
+
+test('rejects an empty input array', () => {
+  assert.throws(() => mergeCoberturaStrings([]), /non-empty/)
+})
+
+test('CLI: --out without a value exits non-zero', () => {
+  assert.throws(
+    () => execFileSync('node', [SCRIPT, 'some.xml', '--out'], { stdio: 'pipe' }),
+    (err) => err.status === 2,
+  )
 })

--- a/scripts/ci/merge-cobertura.test.mjs
+++ b/scripts/ci/merge-cobertura.test.mjs
@@ -1,0 +1,69 @@
+// Unit tests for the zero-dependency Cobertura merge helper (DR-T1, task-3/4).
+// Run: node --test scripts/ci/merge-cobertura.test.mjs
+//
+// The helper exists so a TS monorepo (separate vitest project roots) can hand the
+// org coverage-gate ONE merged Cobertura — keeping the parity-critical `aggregate`
+// default usable — without a .NET ReportGenerator. It merges the root count
+// attributes (lines/branches valid+covered), recomputes the root rates from the
+// summed totals, and unions the per-<package> rows (disjoint across projects).
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mergeCoberturaStrings } from './merge-cobertura.mjs'
+
+const fileA = `<?xml version="1.0" ?>
+<coverage line-rate="0.9" branch-rate="0.8" lines-valid="100" lines-covered="90" branches-valid="50" branches-covered="40" version="1.9" timestamp="0">
+  <sources><source>/repo</source></sources>
+  <packages>
+    <package name="src" line-rate="0.9" branch-rate="0.8"><classes/></package>
+  </packages>
+</coverage>`
+
+const fileB = `<?xml version="1.0" ?>
+<coverage line-rate="0.8" branch-rate="0.6" lines-valid="100" lines-covered="80" branches-valid="50" branches-covered="30" version="1.9" timestamp="0">
+  <sources><source>/repo/servers/mcp</source></sources>
+  <packages>
+    <package name="servers/mcp/src" line-rate="0.8" branch-rate="0.6"><classes/></package>
+  </packages>
+</coverage>`
+
+test('merges root counts and recomputes the aggregate rates', () => {
+  const merged = mergeCoberturaStrings([fileA, fileB])
+  // lines: (90+80)/(100+100) = 0.85 ; branches: (40+30)/(50+50) = 0.70
+  assert.match(merged, /lines-valid="200"/)
+  assert.match(merged, /lines-covered="170"/)
+  assert.match(merged, /branches-valid="100"/)
+  assert.match(merged, /branches-covered="70"/)
+  const lineRate = Number(merged.match(/<coverage[^>]*\bline-rate="([0-9.]+)"/)[1])
+  const branchRate = Number(merged.match(/<coverage[^>]*\bbranch-rate="([0-9.]+)"/)[1])
+  assert.ok(Math.abs(lineRate - 0.85) < 1e-6, `line-rate ${lineRate} != 0.85`)
+  assert.ok(Math.abs(branchRate - 0.7) < 1e-6, `branch-rate ${branchRate} != 0.70`)
+})
+
+test('unions per-package rows from every input (disjoint projects)', () => {
+  const merged = mergeCoberturaStrings([fileA, fileB])
+  assert.match(merged, /<package name="src"/)
+  assert.match(merged, /<package name="servers\/mcp\/src"/)
+})
+
+test('a single input round-trips its aggregate rate', () => {
+  const merged = mergeCoberturaStrings([fileA])
+  const lineRate = Number(merged.match(/<coverage[^>]*\bline-rate="([0-9.]+)"/)[1])
+  assert.ok(Math.abs(lineRate - 0.9) < 1e-6, `line-rate ${lineRate} != 0.90`)
+})
+
+test('zero branches does not divide by zero', () => {
+  const noBranch = fileA
+    .replace(/branches-valid="50"/, 'branches-valid="0"')
+    .replace(/branches-covered="40"/, 'branches-covered="0"')
+  const merged = mergeCoberturaStrings([noBranch])
+  const branchRate = Number(merged.match(/<coverage[^>]*\bbranch-rate="([0-9.]+)"/)[1])
+  assert.equal(branchRate, 0)
+})
+
+test('emits a single well-formed <coverage> root', () => {
+  const merged = mergeCoberturaStrings([fileA, fileB])
+  assert.equal(merged.match(/<coverage[\s>]/g).length, 1)
+  assert.equal(merged.match(/<\/coverage>/g).length, 1)
+  assert.match(merged, /^<\?xml/)
+})

--- a/scripts/ci/testdata/ts-canary-fixture/.gitignore
+++ b/scripts/ci/testdata/ts-canary-fixture/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+coverage/
+package-lock.json

--- a/scripts/ci/testdata/ts-canary-fixture/package.json
+++ b/scripts/ci/testdata/ts-canary-fixture/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ts-canary-fixture",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "description": "Minimal vitest project exercised by canary-node-ci.yml. Intentionally <100% covered so the gate can be asserted to pass at a low threshold and fail at 100.",
+  "scripts": {
+    "test": "vitest run",
+    "bench": "vitest bench --run"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^3.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/scripts/ci/testdata/ts-canary-fixture/src/add.bench.ts
+++ b/scripts/ci/testdata/ts-canary-fixture/src/add.bench.ts
@@ -1,0 +1,6 @@
+import { bench } from 'vitest'
+import { add } from './add'
+
+bench('add', () => {
+  add(1, 2)
+})

--- a/scripts/ci/testdata/ts-canary-fixture/src/add.test.ts
+++ b/scripts/ci/testdata/ts-canary-fixture/src/add.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest'
+import { add, classify } from './add'
+
+test('add sums two numbers', () => {
+  expect(add(1, 2)).toBe(3)
+})
+
+test('classify positive', () => {
+  expect(classify(1)).toBe('positive')
+})

--- a/scripts/ci/testdata/ts-canary-fixture/src/add.ts
+++ b/scripts/ci/testdata/ts-canary-fixture/src/add.ts
@@ -1,0 +1,12 @@
+export function add(a: number, b: number): number {
+  return a + b
+}
+
+// classify() has three branches; the test exercises only the positive branch,
+// leaving the negative/zero paths uncovered so the fixture is intentionally
+// <100% covered (lets the canary assert pass-at-low / fail-at-100 thresholds).
+export function classify(n: number): string {
+  if (n > 0) return 'positive'
+  if (n < 0) return 'negative'
+  return 'zero'
+}

--- a/scripts/ci/testdata/ts-canary-fixture/tsconfig.json
+++ b/scripts/ci/testdata/ts-canary-fixture/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/scripts/ci/testdata/ts-canary-fixture/vitest.config.ts
+++ b/scripts/ci/testdata/ts-canary-fixture/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+
+// Coverage config; the node-build-test action also passes --coverage flags on the
+// CLI, but pinning include/exclude here keeps the measured % deterministic.
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text-summary', 'cobertura'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/**/*.bench.ts'],
+    },
+  },
+})

--- a/scripts/ci/testdata/ts-vitest.cobertura.xml
+++ b/scripts/ci/testdata/ts-vitest.cobertura.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<!--
+  Cross-language fixture (DR-T2): a vitest/istanbul-reports `cobertura` output,
+  NOT a .NET one. Two things differ from the C# fixtures and are exactly what we
+  assert the org gate tolerates:
+    1. <package name> is a SOURCE DIRECTORY (incl. a nested, slash-containing
+       monorepo path) — not a dotted assembly name.
+    2. an istanbul DOCTYPE + per-line <lines> subtree the gate must ignore.
+  Aggregate: line 180/200 = 0.90, branch 85/100 = 0.85.
+-->
+<coverage lines-valid="200" lines-covered="180" line-rate="0.9" branches-valid="100" branches-covered="85" branch-rate="0.85" timestamp="0" complexity="0" version="0.1">
+  <sources>
+    <source>/repo</source>
+  </sources>
+  <packages>
+    <package name="src" line-rate="0.92" branch-rate="0.88" complexity="0">
+      <classes>
+        <class name="index.ts" filename="src/index.ts" line-rate="0.92" branch-rate="0.88" complexity="0">
+          <methods/>
+          <lines>
+            <line number="1" hits="1"/>
+            <line number="2" hits="1"/>
+            <line number="3" hits="0"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+    <package name="servers/exarchos-mcp/src" line-rate="0.88" branch-rate="0.82" complexity="0">
+      <classes>
+        <class name="server.ts" filename="servers/exarchos-mcp/src/server.ts" line-rate="0.88" branch-rate="0.82" complexity="0">
+          <methods/>
+          <lines>
+            <line number="1" hits="3"/>
+            <line number="2" hits="0"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>


### PR DESCRIPTION
## TypeScript composable CI layer (T1–T9 of `ts-composable-ci`)

Implements the org-side of the TS layer designed in
`docs/designs/2026-06-15-ts-composable-ci.md` (DR-T1..DR-T4). The **C# `v1` layer
is untouched** — this is purely additive. Discovery: `docs/research/2026-06-15-ts-composable-ci.md`.

### What's here
- **`node-build-test`** composite action — lockfile package-manager auto-detect
  (npm/pnpm/bun), `tsc --noEmit`, **opt-in** lint, `vitest` coverage, and **one
  merged Cobertura** via the shared `scripts/ci/merge-cobertura.mjs`. Emits the
  **same `coverage-reports` artifact contract** as `dotnet-build-test`.
- **`coverage-gate` is REUSED unchanged** — no TS-native gate. Proven by a
  cross-language vitest/istanbul fixture + **6 new harness cases** (directory-style
  `<package>` names incl. the grep/sed fallback). The discovery's "the gate is
  language-agnostic" claim is now locked under test.
- **`scripts/ci/merge-cobertura.mjs`** — zero-dependency pure-JS merge (keeps
  `.github` dep-free) with a `node:test` unit test.
- **`node-benchmark-smoke`** composite action (`vitest bench`), opt-in.
- **`node-build-test.yml`** thin preset workflow.
- **`canary-node-ci.yml`** — end-to-end (build-test → merge → gate **pass@1 /
  fail@100**), benchmark smoke, and a package-manager auto-detect matrix, against a
  committed fixture vitest project.
- TS consumer-guide section (incl. the **per-directory** `per-assembly` granularity note).

### Verification (local)
- `node --test scripts/ci/merge-cobertura.test.mjs` → **5/5**
- `bash scripts/ci/coverage-gate.test.sh` → **34/34** (28 existing + 6 new DR-T2)
- `actionlint` clean on all workflows
- Full fixture e2e: `vitest` cobertura → `merge-cobertura.mjs` → `coverage-gate.sh`
  passes@1 / fails@100. The `canary-node-ci` workflow re-runs this on CI.

### Deferred (not in this PR)
- **T10 — release `v1.1`** (additive) + repin the preset's internal
  `node-build-test@main` to the release SHA. Follows the v1 → #14 pattern (a
  separate release PR). `node-build-test.yml`'s internal ref is `@main` until then.
- **T11–T12 — exarchos migration** onto the layer, tracked in
  lvlup-sw/exarchos#1539, gated on the `v1.1` tag.

Refs #12 · unblocks lvlup-sw/exarchos#1539
