### PR TITLE
feat(ci): add optional test-filter input to dotnet-build-test

### DIFF
--- a/actions/dotnet-build-test/action.yml
+++ b/actions/dotnet-build-test/action.yml
@@ -33,6 +33,15 @@ inputs:
     description: 'Newline-separated glob patterns to skip (e.g., *Integration.Tests*)'
     required: false
     default: ''
+  test-filter:
+    description: >-
+      Microsoft.Testing.Platform --treenode-filter expression applied to every
+      test project, scoping which tests run within each (e.g.
+      "/*/*/*/*[Category!=Stress]" to exclude a category that runs in a separate
+      gated job). Empty (the default) runs every test, so existing consumers are
+      unaffected.
+    required: false
+    default: ''
   coverage-filters:
     description: 'ReportGenerator -assemblyfilters value'
     required: false
@@ -78,10 +87,17 @@ runs:
       env:
         TEST_PROJECT_PATTERNS: ${{ inputs.test-project-patterns }}
         SKIP_PATTERNS: ${{ inputs.skip-patterns }}
+        TEST_FILTER: ${{ inputs.test-filter }}
       run: |
         set -uo pipefail
         mkdir -p ./TestResults
         failed=0
+
+        # Optional MTP --treenode-filter, applied to every project (e.g. to
+        # exclude a [Category=...] that runs in a separate gated job). Empty =
+        # run all tests, so the flag is omitted entirely.
+        filter_args=()
+        [[ -n "$TEST_FILTER" ]] && filter_args+=(--treenode-filter "$TEST_FILTER")
 
         while IFS= read -r pattern; do
           [[ -z "$pattern" ]] && continue
@@ -109,6 +125,7 @@ runs:
             echo "Running tests: $proj"
 
             if ! dotnet run --project "$proj" --configuration Release -- \
+              "${filter_args[@]}" \
               --coverage \
               --coverage-output-format cobertura \
               --coverage-output "$coverage_path"; then

--- a/docs/guides/org-ci-consumer-guide.md
+++ b/docs/guides/org-ci-consumer-guide.md
@@ -151,7 +151,11 @@ unaffected.
   replace bespoke build/test/coverage steps with `dotnet-build-test` +
   `coverage-gate`; add `aot-smoke` / `benchmark-smoke` only if you need them.
 - **Reference consumer** (bifrost): see `lvlup-sw/bifrost#39` — composes all four
-  actions including the per-assembly + branch gate.
+  actions including the per-assembly + branch gate, and passes the
+  `dotnet-build-test` `test-filter` input (`v1.2`+) an MTP `--treenode-filter` to
+  exclude its `[Category=Stress]` proofs from the per-PR run (those run in a
+  separate gated job). `test-filter` is optional and empty by default, so it
+  changes nothing for other consumers.
 
 ## TypeScript / Node consumers (`v1.1`+)
 


### PR DESCRIPTION
## Summary

Adds an optional **`test-filter`** input to the `dotnet-build-test` composite action. When set, it is passed as the Microsoft Testing Platform `--treenode-filter` to every test project's `dotnet run`. Default is empty (the flag is omitted entirely).

## Why

bifrost is the reference consumer for the org CI layer (lvlup-sw/bifrost#39). Its build-test run excludes `[Category=Stress]` proofs — CPU-bound multi-core contention tests that run in a **separate gated job** and starve/flake under `--coverage` on a 4-vcpu runner. The existing `skip-patterns` input can't express this: the stress tests live in `Bifrost.Tests.Concurrency`, which *also* holds the non-stress tests that supply that assembly's coverage, so skipping the whole project would red the per-assembly gate.

`test-filter` lets a consumer scope execution *within* each project (any MTP treenode expression), which `skip-patterns` (whole-project) cannot.

## Backward compatibility

- Default empty → the `--treenode-filter` flag is omitted, so the `dotnet run` invocation is **byte-for-byte unchanged** for every existing consumer (strategos / basileus / DataFerry) and for the `build-and-test.yml` preset (which doesn't pass the new input).
- Additive, optional input only. The `canary-build-test` parity check (triggered by `actions/dotnet-build-test/**`) exercises the unchanged default path.

## Scope

Action only — `build-and-test.yml` is intentionally left untouched (it SHA-pins the action; wiring the passthrough would force a self-referential repin across the release boundary, and no preset consumer needs category filtering). Consumers that need `test-filter` compose the action directly, which is the documented advanced path.

Cut as **`v1.2`** after merge; bifrost pins to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)