### PR TITLE
feat(ci): CodeQL + dependency-review reusable workflows + canaries

### DIFF
--- a/.github/workflows/canary-codeql.yml
+++ b/.github/workflows/canary-codeql.yml
@@ -1,0 +1,44 @@
+# =============================================================================
+# Canary: codeql.yml reusable workflow
+# =============================================================================
+# Chain-specific canary proving THIS repo's `codeql.yml` reusable resolves and
+# runs init + analyze end to end, on every PR that touches the reusable or its
+# fixture. It calls the reusable with `languages: csharp` + `build-mode: none`
+# (the production buildless path) against the committed C# fixture in
+# scripts/ci/testdata/csharp-canary-fixture/, and passes `upload: never` +
+# `upload-database: false` so the canary needs no Code Scanning enablement —
+# a green job means the reusable's interface and the buildless analysis both
+# work.
+#
+# Dedicated canary file (not a shared canary) to avoid cross-chain conflicts,
+# mirroring canary-coverage-gate.yml.
+# =============================================================================
+
+name: Canary - CodeQL Reusable
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/codeql.yml'
+      - '.github/workflows/canary-codeql.yml'
+      - 'scripts/ci/testdata/csharp-canary-fixture/**'
+
+permissions:
+  contents: read
+
+jobs:
+  # Calls the reusable on its own PR ref (uses: ./...) so the canary exercises
+  # THIS PR's codeql.yml, not main. security-events: write is granted for parity
+  # with production even though upload: never means nothing is uploaded.
+  buildless-csharp:
+    name: Buildless csharp analysis runs (upload never)
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    uses: ./.github/workflows/codeql.yml
+    with:
+      languages: csharp
+      build-mode: none
+      upload: never
+      upload-database: false

--- a/.github/workflows/canary-dependency-review.yml
+++ b/.github/workflows/canary-dependency-review.yml
@@ -1,0 +1,33 @@
+# =============================================================================
+# Canary: dependency-review.yml reusable workflow
+# =============================================================================
+# Chain-specific canary proving THIS repo's `dependency-review.yml` reusable
+# resolves and runs on a real pull_request. Dependency review is available on
+# public repos without GHAS, so a green job here means the reusable's interface
+# works and the action runs against the PR's base..head dependency graph (a PR
+# that introduces no vulnerable dependencies passes — the expected verdict for
+# a workflow-only change).
+#
+# Dedicated canary file, mirroring canary-coverage-gate.yml.
+# =============================================================================
+
+name: Canary - Dependency Review Reusable
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/dependency-review.yml'
+      - '.github/workflows/canary-dependency-review.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  runs-on-pr:
+    name: Dependency review runs on the PR
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/dependency-review.yml
+    with:
+      fail-on-severity: high

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,100 @@
+# =============================================================================
+# Reusable Workflow: CodeQL Static Analysis (SAST)
+# =============================================================================
+# Promotes the CodeQL analysis that hierophant ran inline (and basileus runs in
+# per-stack-gates.yml) into an org reusable workflow — closing stack-seed §7.3
+# gap #3. Buildless analysis by default (`build-mode: none`), so no project
+# compile is required.
+#
+# Thin `workflow_call` PRESET over `github/codeql-action` (single source of
+# truth — the analysis logic lives in the action). Mirrors the convention of
+# build-and-test.yml / coverage-gate.yml: this workflow owns only the
+# workflow-level concerns (runs-on, the workflow_call signature, least-privilege
+# permissions); everything else is a documented passthrough input.
+#
+# The CALLER owns event triggers (push/pull_request/schedule) and any
+# GHAS/`vars.GHAS_ENABLED` gating — keep this workflow free of policy so every
+# consumer can apply its own.
+#
+# Usage:
+#   jobs:
+#     codeql:
+#       permissions:
+#         contents: read
+#         security-events: write
+#         actions: read
+#       uses: lvlup-sw/.github/.github/workflows/codeql.yml@v1
+#       with:
+#         languages: csharp        # buildless by default
+# =============================================================================
+
+name: CodeQL
+
+on:
+  workflow_call:
+    inputs:
+      languages:
+        description: 'Comma-separated CodeQL languages (e.g. csharp, javascript-typescript, actions).'
+        required: false
+        type: string
+        default: 'csharp'
+      build-mode:
+        description: 'CodeQL build mode for compiled languages (none | autobuild | manual). Buildless by default.'
+        required: false
+        type: string
+        default: 'none'
+      runner:
+        description: 'GitHub Actions runner label. CodeQL runs on GitHub-hosted by default.'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      queries:
+        description: 'Comma-separated additional query suites/packs. Prefix with "+" to add to (not replace) config queries.'
+        required: false
+        type: string
+        default: ''
+      config-file:
+        description: 'Path to a CodeQL config file (optional).'
+        required: false
+        type: string
+        default: ''
+      upload:
+        description: "Upload SARIF to Code Scanning: always (default) | failure-only | never. Canaries pass 'never'."
+        required: false
+        type: string
+        default: 'always'
+      upload-database:
+        description: 'Whether to upload the resulting CodeQL database. Canaries pass false.'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ inputs.languages }})
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write   # upload CodeQL results to the Security tab
+      actions: read            # read the base run for the PR overlay cache (private repos)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          languages: ${{ inputs.languages }}
+          build-mode: ${{ inputs.build-mode }}
+          queries: ${{ inputs.queries }}
+          config-file: ${{ inputs.config-file }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          category: "/language:${{ inputs.languages }}"
+          upload: ${{ inputs.upload }}
+          upload-database: ${{ inputs.upload-database }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,65 @@
+# =============================================================================
+# Reusable Workflow: Dependency Review (supply chain)
+# =============================================================================
+# Promotes the dependency-review job that hierophant ran inline into an org
+# reusable workflow. Fails a PR when it introduces dependencies with known
+# vulnerabilities (and, once Phase 5 sets it, disallowed licenses).
+#
+# Thin `workflow_call` PRESET over `actions/dependency-review-action`. The action
+# only works on `pull_request` events (it diffs the PR's base..head dependency
+# graph), so the CALLER must invoke this from a pull_request-triggered workflow
+# and owns any GHAS/`vars.GHAS_ENABLED` gating.
+#
+# License allow/deny policy is intentionally NOT set here — it is deferred to
+# Phase 5 governance (design Open Question), at which point `allow-licenses` /
+# `deny-licenses` inputs are threaded through.
+#
+# Usage:
+#   on: pull_request
+#   jobs:
+#     dependency-review:
+#       if: vars.GHAS_ENABLED == 'true'
+#       uses: lvlup-sw/.github/.github/workflows/dependency-review.yml@v1
+#       with:
+#         fail-on-severity: high
+# =============================================================================
+
+name: Dependency Review
+
+on:
+  workflow_call:
+    inputs:
+      fail-on-severity:
+        description: 'Minimum severity that fails the PR: low | moderate | high | critical.'
+        required: false
+        type: string
+        default: 'high'
+      runner:
+        description: 'GitHub Actions runner label.'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      comment-summary-in-pr:
+        description: 'Post the dependency-review summary as a PR comment: always | on-failure | never.'
+        required: false
+        type: string
+        default: 'never'
+
+jobs:
+  review:
+    name: Dependency Review
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      pull-requests: write   # only used when comment-summary-in-pr != never
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: ${{ inputs.fail-on-severity }}
+          comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}

--- a/docs/designs/2026-06-20-codeql-dep-review-reusables.md
+++ b/docs/designs/2026-06-20-codeql-dep-review-reusables.md
@@ -1,0 +1,23 @@
+# Design: CodeQL + Dependency-Review reusable workflows
+
+**Driver:** `lvlup-sw/hierophant` epic #1 (paved road), Phase 2 remainder (#13). Spike for Phase 3 (#14) — the `LevelUp.Templates` scaffolded `ci.yml` must reference real org reusables.
+**Source design (consumer side):** `hierophant/docs/designs/2026-06-20-levelup-templates.md` (D1, DR-1…DR-6).
+
+## Problem
+`lvlup-sw/.github` hosts the org's reusable CI suite (`build-and-test.yml`, `coverage-gate.yml`, `format-check.yml`, `node-build-test.yml`, `update-baseline.yml`), each with a composite-action backing and a `canary-*` self-test. **CodeQL and dependency-review are missing** — they still live inline in `hierophant` (`codeql.yml`, the `ci.yml` `dependency-review` job), explicitly flagged there as "the reference to promote once a second repo needs it" (stack-seed §7.3 gap #3). Phase 3 is that second consumer.
+
+## Chosen approach
+Two thin `workflow_call` PRESET workflows over the upstream actions — matching the repo's existing wrapper convention (logic in the action, workflow owns only runs-on + the call signature + least-privilege perms). CodeQL needs no composite (it is already action-driven); a thin reusable is sufficient.
+
+- **`codeql.yml`** — buildless by default (`build-mode: none`), `languages` default `csharp`. Caller owns event triggers (push/pull_request/schedule) and any `GHAS_ENABLED` gating. `upload`/`upload-database` are passthrough so canaries can run without Code Scanning enabled. Actions SHA-pinned to the refs hierophant already proved (`github/codeql-action@dd903d2e` v3).
+- **`dependency-review.yml`** — wraps `actions/dependency-review-action@2031cfc0` (v4), `fail-on-severity` default `high`. PR-event only (the action diffs base..head); caller owns the `pull_request` trigger + gating. License allow/deny deferred to Phase 5.
+
+## Canaries (self-test)
+- **`canary-codeql.yml`** — calls the reusable on its PR ref with `csharp` + `build-mode: none` against `scripts/ci/testdata/csharp-canary-fixture/`, `upload: never`, `upload-database: false`. Green job = the buildless path runs. No Code Scanning enablement required.
+- **`canary-dependency-review.yml`** — calls the reusable on a real PR; dependency review is available on this public repo without GHAS, so a workflow-only PR (no vulnerable deps added) passes.
+
+## Versioning / rollout
+Merge to `main`, then move the moving `v1` tag (and cut `v1.3`) to the merge commit so `@v1` consumers (starting with hierophant) receive codeql/dependency-review. Renovate keeps the action pins current.
+
+## Consumer wiring (hierophant, separate PR)
+hierophant replaces its inline `codeql.yml` + `ci.yml` `dependency-review` job with `uses:` calls to these reusables, SHA-pinned `# v1`, preserving its `vars.GHAS_ENABLED` gate, weekly CodeQL schedule, and PR-scoped dependency review. Its `scripts/verify-ci-workflows.sh` contract follows the logic to its new home.

--- a/scripts/ci/testdata/csharp-canary-fixture/Program.cs
+++ b/scripts/ci/testdata/csharp-canary-fixture/Program.cs
@@ -1,0 +1,20 @@
+// Minimal C# source for the CodeQL reusable-workflow canary.
+//
+// CodeQL's `csharp` extractor at `build-mode: none` performs buildless
+// extraction over .cs sources — a single source file is enough to produce a
+// database and exercise init + analyze end to end. The canary runs with
+// `upload: never`, so this fixture only needs to be syntactically valid C#;
+// no real finding is asserted (the canary proves the reusable runs, not that
+// any specific query fires).
+
+namespace Lvlup.Ci.CodeqlCanary;
+
+internal static class Program
+{
+    private static int Add(int a, int b) => a + b;
+
+    private static void Main()
+    {
+        System.Console.WriteLine(Add(2, 3));
+    }
+}


### PR DESCRIPTION
## What

Promote the inline **CodeQL** analysis and **dependency-review** job (currently in `lvlup-sw/hierophant`) to **org reusable workflows**, with dedicated `canary-*` self-tests — matching the repo's existing thin-wrapper + canary convention.

Closes stack-seed §7.3 gap #3 and the **Phase 2 remainder** (hierophant #13). Unblocks **Phase 3 — `LevelUp.Templates`** (hierophant #14), whose scaffolded `ci.yml` must reference real org reusables.

## Workflows

| File | Purpose |
|---|---|
| `.github/workflows/codeql.yml` | Thin `workflow_call` preset over `github/codeql-action`. Buildless by default (`build-mode: none`), `languages` default `csharp`. `upload`/`upload-database` passthrough so canaries run without Code Scanning enabled. **Caller owns** triggers + `GHAS_ENABLED` gating. |
| `.github/workflows/dependency-review.yml` | Thin preset over `actions/dependency-review-action`, `fail-on-severity` default `high`. PR-event only. License allow/deny deferred to Phase 5. |
| `.github/workflows/canary-codeql.yml` | Exercises the buildless csharp path against `scripts/ci/testdata/csharp-canary-fixture/`, `upload: never` — green job proves the reusable runs, no Code Scanning enablement required. |
| `.github/workflows/canary-dependency-review.yml` | Runs the reusable on a real PR (public repo → no GHAS required). |

## Notes

- Actions **SHA-pinned** to the exact refs hierophant already proved (`codeql-action@dd903d2e` v3, `dependency-review-action@2031cfc0` v4). Renovate keeps them current.
- All four workflows pass `actionlint` (incl. local reusable-call signature validation).
- **After merge:** move the `v1` tag and cut `v1.3` to the merge commit so `@v1` consumers (starting with hierophant) receive these reusables.

Design: `docs/designs/2026-06-20-codeql-dep-review-reusables.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)