### PR TITLE
feat(ci): tiered per-assembly coverage thresholds + opt-in generated-exclusion (#21)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,6 +54,11 @@ on:
         required: false
         type: string
         default: ''
+      exclude-generated:
+        description: 'When true, exclude generated code (GeneratedCodeAttribute + .g.cs/.Designer.cs) from coverage collection via a default code-coverage settings file. Opt-in; default false leaves collection unchanged.'
+        required: false
+        type: boolean
+        default: false
       runner:
         description: 'GitHub Actions runner label'
         required: false
@@ -99,5 +104,6 @@ jobs:
           test-project-patterns: ${{ inputs.test-project-patterns }}
           skip-patterns: ${{ inputs.skip-patterns }}
           coverage-filters: ${{ inputs.coverage-filters }}
+          exclude-generated: ${{ inputs.exclude-generated }}
           dotnet-version: ${{ inputs.dotnet-version }}
           dotnet-quality: ${{ inputs.dotnet-quality }}

--- a/.github/workflows/canary-build-test.yml
+++ b/.github/workflows/canary-build-test.yml
@@ -141,3 +141,58 @@ jobs:
           path: ./TestResults/coverage.cobertura.xml
           retention-days: 7
           if-no-files-found: warn
+
+  # --------------------------------------------------------------------------
+  # Fast gate for the opt-in generated-exclusion settings file (issue #21,
+  # part 2). The full collector-acceptance run happens when a consumer (bifrost
+  # / basileus) opts into exclude-generated=true; this cheap job catches the
+  # realistic failure mode here — a malformed or content-incomplete settings
+  # file — on every PR that touches the action, without a second bifrost build
+  # (the action's hardcoded 'coverage-reports' artifact upload makes running the
+  # action twice in one workflow run collide under upload-artifact@v4).
+  # --------------------------------------------------------------------------
+  validate-coverage-settings:
+    name: Validate generated-exclusion coverage settings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Settings file is well-formed XML and excludes generated code
+        run: |
+          set -euo pipefail
+          f=actions/dotnet-build-test/coverage-settings.generated-exclusion.xml
+
+          if [[ ! -f "$f" ]]; then
+            echo "::error::missing settings file $f"; exit 1
+          fi
+
+          # Well-formedness (python3 is always present on ubuntu-latest).
+          python3 -c "import xml.dom.minidom,sys; xml.dom.minidom.parse(sys.argv[1])" "$f"
+          echo "well-formed XML: OK"
+
+          # Inspect only the actual exclude ELEMENT lines, not the comment (the
+          # comment names CompilerGeneratedAttribute to explain its absence).
+          # The file content is itself ECMAScript regex, so match fixed strings.
+          attr_lines="$(grep -F '<Attribute>' "$f" || true)"
+          src_lines="$(grep -F '<Source>' "$f" || true)"
+
+          if ! grep -Fq 'GeneratedCodeAttribute' <<<"$attr_lines"; then
+            echo "::error::no GeneratedCodeAttribute exclude"; exit 1
+          fi
+          if ! grep -Fq 'ExcludeFromCodeCoverageAttribute' <<<"$attr_lines"; then
+            echo "::error::ExcludeFromCodeCoverage exclude not preserved"; exit 1
+          fi
+          if ! grep -Fq 'g\.cs' <<<"$src_lines"; then
+            echo "::error::no .g.cs source exclude"; exit 1
+          fi
+          if ! grep -Fq 'IncludeTestAssembly>False' "$f"; then
+            echo "::error::IncludeTestAssembly must be False"; exit 1
+          fi
+
+          # CompilerGeneratedAttribute must NOT be an excluded attribute (would
+          # drop async/await/yield/auto-props from coverage).
+          if grep -Fq 'CompilerGeneratedAttribute' <<<"$attr_lines"; then
+            echo "::error::CompilerGeneratedAttribute must not be excluded"; exit 1
+          fi
+          echo "generated-exclusion settings file: VALID"

--- a/.github/workflows/canary-coverage-gate.yml
+++ b/.github/workflows/canary-coverage-gate.yml
@@ -118,3 +118,67 @@ jobs:
           cat ./coverage-assembly/pr-comment.md
           grep -q 'Bifrost.Core' ./coverage-assembly/pr-comment.md
           echo "Canary OK: opt-in per-assembly+branch gate fails the seeded sub-threshold assembly."
+
+  # --------------------------------------------------------------------------
+  # (c) Tiered thresholds (issue #21): a risk-tiered floor map raises ONE
+  # assembly's floor above its actual coverage and FAILS an otherwise-passing
+  # report — proving the new `assembly-thresholds` input is wired end-to-end
+  # through the action (workflow input -> action input -> ASSEMBLY_THRESHOLDS
+  # env -> gate script). The all-passing fixture (every assembly >= 80/80) is
+  # gated with a 95/90 floor on Bifrost.Scheduling.Core (0.92 line / 0.84
+  # branch), which must drop below the raised floor while the others stay green.
+  # --------------------------------------------------------------------------
+  per-assembly-tiered-failure:
+    name: Per-assembly tiered floor fails an assembly above its raised floor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (provides the local action + fixtures)
+        uses: actions/checkout@v4
+
+      - name: Stage all-passing fixture as the merged report
+        run: |
+          mkdir -p ./coverage-tiered
+          cp scripts/ci/testdata/merged-multipackage-pass.cobertura.xml \
+             ./coverage-tiered/Cobertura.xml
+
+      - name: Run gate per-assembly with a tiered floor raising Scheduling.Core
+        id: gate
+        continue-on-error: true
+        uses: ./actions/coverage-gate
+        with:
+          threshold: '80'
+          gate-mode: per-assembly
+          coverage-file: ./coverage-tiered/Cobertura.xml
+          output-dir: ./coverage-tiered
+          assembly-thresholds: |
+            *Scheduling.Core = 95/90
+          shared-ref: ${{ github.sha }}
+
+      - name: Assert FAIL verdict + tiered floor shown in comment
+        run: |
+          if [ "${{ steps.gate.outcome }}" != "failure" ]; then
+            echo "::error::tiered gate expected to FAIL (Scheduling.Core 92% < 95 floor) but outcome was '${{ steps.gate.outcome }}'"
+            exit 1
+          fi
+          echo "Tiered FAILURE recorded as expected. PR comment:"
+          cat ./coverage-tiered/pr-comment.md
+          # The Threshold column must surface the raised floor for the assembly.
+          grep -q '95/90' ./coverage-tiered/pr-comment.md
+          grep -q 'Bifrost.Scheduling.Core' ./coverage-tiered/pr-comment.md
+          echo "Canary OK: per-assembly tiered floor map fails an assembly above its raised floor."
+
+  # --------------------------------------------------------------------------
+  # (d) Unit harness: run the plain-bash coverage-gate.sh test suite in CI so
+  # the gate's verdict + backward-compat parity cases (including the new tiered
+  # threshold cases) actually gate PRs. The harness was previously run only
+  # manually; this canary already triggers on scripts/ci/** changes.
+  # --------------------------------------------------------------------------
+  gate-script-unit-tests:
+    name: coverage-gate.sh unit harness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run coverage-gate.sh test harness
+        run: bash scripts/ci/coverage-gate.test.sh

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -56,6 +56,11 @@ on:
         required: false
         type: string
         default: 'line'
+      assembly-thresholds:
+        description: 'gate-mode=per-assembly only: newline-separated "GLOB = LINE[/BRANCH]" risk-tiered floor rules. First match wins; unmatched assemblies use coverage-threshold. Pass-through to the coverage-gate action.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   coverage-gate:
@@ -96,6 +101,7 @@ jobs:
           threshold: ${{ inputs.coverage-threshold }}
           gate-mode: ${{ inputs.gate-mode }}
           metrics: ${{ inputs.metrics }}
+          assembly-thresholds: ${{ inputs.assembly-thresholds }}
           coverage-file: ./coverage-merged/Cobertura.xml
           report-dir: ./coverage-reports
           output-dir: ./coverage-merged

--- a/actions/coverage-gate/action.yml
+++ b/actions/coverage-gate/action.yml
@@ -17,6 +17,7 @@
 #   gate-mode=per-assembly  -> --per-assembly  <coverage-file>
 #   metrics=line|line+branch-> --metrics <metrics>   (aggregate mode only)
 #   exclude="<globs>"       -> --exclude <glob> (repeated, per-project/assembly)
+#   assembly-thresholds=... -> ASSEMBLY_THRESHOLDS env (per-assembly tiered floors)
 #   threshold=N             -> --threshold N
 #   output-dir=DIR          -> --output-dir DIR
 #
@@ -53,6 +54,15 @@ inputs:
     default: './coverage-reports'
   exclude:
     description: 'Whitespace-separated globs of units to skip (per-project: Cobertura file name; per-assembly: <package> name). One --exclude per glob.'
+    required: false
+    default: ''
+  assembly-thresholds:
+    description: >-
+      (gate-mode=per-assembly only) Optional risk-tiered floor map: a
+      newline-separated list of "GLOB = LINE[/BRANCH]" rules applied to each
+      <package> whose name matches GLOB. First matching rule wins; assemblies
+      matching no rule fall back to `threshold`. Omit BRANCH (e.g.
+      "*.Host = 70") to gate line only. Passed to the gate as ASSEMBLY_THRESHOLDS.
     required: false
     default: ''
   output-dir:
@@ -93,6 +103,7 @@ runs:
         COVERAGE_FILE: ${{ inputs.coverage-file }}
         REPORT_DIR: ${{ inputs.report-dir }}
         EXCLUDE_GLOBS: ${{ inputs.exclude }}
+        ASSEMBLY_THRESHOLDS: ${{ inputs.assembly-thresholds }}
         OUTPUT_DIR: ${{ inputs.output-dir }}
       run: |
         set -euo pipefail

--- a/actions/dotnet-build-test/action.yml
+++ b/actions/dotnet-build-test/action.yml
@@ -13,6 +13,9 @@
 #   - Each test project produces a Cobertura XML report
 #   - Reports are merged via ReportGenerator into coverage.cobertura.xml
 #   - Uploaded as the 'coverage-reports' artifact (7-day retention)
+#   - exclude-generated=true passes a default code-coverage settings file
+#     (coverage-settings.generated-exclusion.xml) so generated code is kept out
+#     of the denominator (GeneratedCodeAttribute + .g.cs/.Designer.cs). Opt-in.
 #
 # Skip patterns:
 #   - Use skip-patterns to exclude test projects (e.g., integration tests)
@@ -46,6 +49,16 @@ inputs:
     description: 'ReportGenerator -assemblyfilters value'
     required: false
     default: ''
+  exclude-generated:
+    description: >-
+      When 'true', exclude generated code from coverage collection by passing a
+      default Microsoft code-coverage settings file (coverage-settings) that
+      drops elements carrying [GeneratedCodeAttribute] and sources matching
+      .g.cs / .g.i.cs / .Designer.cs. Defense-in-depth for generators that do
+      not stamp [ExcludeFromCodeCoverage] (issue #21). Opt-in: the default
+      'false' leaves collection byte-for-byte unchanged for existing consumers.
+    required: false
+    default: 'false'
   dotnet-version:
     description: '.NET SDK version (e.g., 9.0.x, 10.0.x)'
     required: false
@@ -88,6 +101,8 @@ runs:
         TEST_PROJECT_PATTERNS: ${{ inputs.test-project-patterns }}
         SKIP_PATTERNS: ${{ inputs.skip-patterns }}
         TEST_FILTER: ${{ inputs.test-filter }}
+        EXCLUDE_GENERATED: ${{ inputs.exclude-generated }}
+        ACTION_PATH: ${{ github.action_path }}
       run: |
         set -uo pipefail
         mkdir -p ./TestResults
@@ -98,6 +113,21 @@ runs:
         # run all tests, so the flag is omitted entirely.
         filter_args=()
         [[ -n "$TEST_FILTER" ]] && filter_args+=(--treenode-filter "$TEST_FILTER")
+
+        # Optional generated-code exclusion: pass a default Microsoft code-
+        # coverage settings file that drops generated code (GeneratedCodeAttribute
+        # + .g.cs/.g.i.cs/.Designer.cs sources) from the denominator. Opt-in;
+        # empty array (the default) leaves the --coverage invocation unchanged.
+        coverage_settings_args=()
+        if [[ "$EXCLUDE_GENERATED" == "true" ]]; then
+          settings_file="${ACTION_PATH}/coverage-settings.generated-exclusion.xml"
+          if [[ -f "$settings_file" ]]; then
+            coverage_settings_args+=(--coverage-settings "$settings_file")
+            echo "Generated-code exclusion ENABLED via $settings_file"
+          else
+            echo "::warning::exclude-generated=true but settings file not found at $settings_file; collecting without it"
+          fi
+        fi
 
         while IFS= read -r pattern; do
           [[ -z "$pattern" ]] && continue
@@ -127,6 +157,7 @@ runs:
             if ! dotnet run --project "$proj" --configuration Release -- \
               "${filter_args[@]}" \
               --coverage \
+              "${coverage_settings_args[@]}" \
               --coverage-output-format cobertura \
               --coverage-output "$coverage_path"; then
               echo "::error::Tests failed for $proj"

--- a/actions/dotnet-build-test/coverage-settings.generated-exclusion.xml
+++ b/actions/dotnet-build-test/coverage-settings.generated-exclusion.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Default Microsoft code-coverage settings for actions/dotnet-build-test when
+  `exclude-generated: true` (issue #21). Passed to the Microsoft.Testing
+  .Extensions.CodeCoverage collector via the coverage-settings option. It keeps
+  generated code out of the coverage denominator by GeneratedCodeAttribute AND
+  by .g.cs / .g.i.cs / .Designer.cs source paths, so generated code never
+  pollutes coverage even for consumers whose generators do not stamp
+  [ExcludeFromCodeCoverage].
+
+  IMPORTANT: a supplied settings file fully specifies the <CodeCoverage> config,
+  so this file deliberately RE-DECLARES the standard defaults it must preserve,
+  rather than only adding the generated-code rules:
+    - ExcludeFromCodeCoverageAttribute is still honored.
+    - DebuggerHidden / DebuggerNonUserCode are still excluded.
+    - IncludeTestAssembly=False keeps test projects out of coverage (the MTP
+      Microsoft.Testing.Extensions.CodeCoverage default; VSTest defaulted true).
+
+  Exclude entries are ECMAScript regular expressions, matched case-insensitively
+  (NOT globs). CompilerGeneratedAttribute is intentionally NOT excluded —
+  excluding it would also drop async/await, yield, and auto-property code from
+  coverage. Schema ref:
+  https://learn.microsoft.com/dotnet/core/additional-tools/dotnet-coverage#settings
+-->
+<Configuration>
+  <CodeCoverage>
+    <IncludeTestAssembly>False</IncludeTestAssembly>
+
+    <!-- Exclude elements carrying these attributes (full name, anchored). -->
+    <Attributes>
+      <Exclude>
+        <Attribute>^System\.Diagnostics\.DebuggerHiddenAttribute$</Attribute>
+        <Attribute>^System\.Diagnostics\.DebuggerNonUserCodeAttribute$</Attribute>
+        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+        <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
+      </Exclude>
+    </Attributes>
+
+    <!-- Exclude elements defined in generated source files (by path suffix). -->
+    <Sources>
+      <Exclude>
+        <Source>.*\.g\.cs$</Source>
+        <Source>.*\.g\.i\.cs$</Source>
+        <Source>.*\.Designer\.cs$</Source>
+      </Exclude>
+    </Sources>
+  </CodeCoverage>
+</Configuration>

--- a/docs/guides/org-ci-consumer-guide.md
+++ b/docs/guides/org-ci-consumer-guide.md
@@ -70,6 +70,14 @@ steps:
         **/tests/**/*.Tests.csproj
 ```
 
+**Optional — keep generated code out of coverage** (`build-and-test.yml` and the
+`dotnet-build-test` action): set `exclude-generated: true` to pass a default
+Microsoft code-coverage settings file during collection that drops elements
+carrying `[GeneratedCodeAttribute]` and sources matching `.g.cs` / `.Designer.cs`.
+Opt-in; the default (`false`) leaves collection unchanged. Use it when a
+source generator emits code that isn't stamped `[ExcludeFromCodeCoverage]` and
+would otherwise dilute the coverage denominator.
+
 ### Pinning the shared gate script
 
 The `coverage-gate` **action** sparse-checks-out the shared
@@ -110,6 +118,7 @@ Opt into stricter gating per repo:
 | `gate-mode` | `aggregate` (default), `per-project`, `per-assembly` | Granularity the threshold is applied at. |
 | `metrics` | `line` (default), `line+branch` | Aggregate mode: also gate branch coverage. |
 | `exclude` | whitespace-separated globs | Skip named projects / assemblies. |
+| `assembly-thresholds` | newline list of `GLOB = LINE[/BRANCH]` | `per-assembly` only: risk-tiered floors. First matching rule wins; unmatched assemblies use `coverage-threshold`. Omit `BRANCH` to gate line only. |
 
 ```yaml
 # bifrost-style strict gate: every assembly ≥ 80% line AND branch
@@ -119,6 +128,23 @@ Opt into stricter gating per repo:
       coverage-threshold: 80
       gate-mode: per-assembly
       metrics: line+branch
+```
+
+```yaml
+# risk-tiered gate: hold security/boundary higher than domain logic, and
+# don't chase branch % on host wiring. coverage-threshold is the fallback floor.
+  coverage:
+    uses: lvlup-sw/.github/.github/workflows/coverage-gate.yml@v1
+    with:
+      coverage-threshold: 80
+      gate-mode: per-assembly
+      assembly-thresholds: |
+        *Identity*            = 85/75
+        *McpToken*            = 85/75
+        *CodeExecutionBridge* = 85/75
+        *Trading*             = 80/70
+        *.Core                = 80/70
+        *.Host                = 70      # line only (boot-tested elsewhere)
 ```
 
 Failure modes are non-vacuous: an empty or fully-excluded unit set exits

--- a/scripts/ci/coverage-gate.sh
+++ b/scripts/ci/coverage-gate.sh
@@ -48,6 +48,25 @@ if [[ -n "${EXCLUDE:-}" ]]; then
     EXCLUDE_GLOBS=(${EXCLUDE})
 fi
 
+# Per-assembly threshold map (--per-assembly mode only). Each rule maps an
+# assembly-name GLOB to a "LINE[/BRANCH]" floor, letting risk-tiered repos hold
+# security/boundary assemblies higher than host wiring (issue #21). Raw rules
+# are seeded from the ASSEMBLY_THRESHOLDS env var (newline-separated; '#'
+# comments and blank lines ignored) and appended to by each --assembly-threshold
+# flag, then parsed into the AT_* parallel arrays AFTER arg parsing (once the
+# logging helpers exist). An assembly that matches NO rule falls back to the
+# global --threshold for both line and branch, so an EMPTY map reproduces
+# today's per-assembly behavior exactly.
+ASSEMBLY_THRESHOLD_RAW=()
+if [[ -n "${ASSEMBLY_THRESHOLDS:-}" ]]; then
+    while IFS= read -r _at_raw_line; do
+        ASSEMBLY_THRESHOLD_RAW+=("$_at_raw_line")
+    done <<< "$ASSEMBLY_THRESHOLDS"
+fi
+AT_GLOBS=()
+AT_LINE=()
+AT_BRANCH=()
+
 # Colors for terminal output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -91,6 +110,17 @@ Options:
                             --per-assembly it matches the <package> NAME. Use
                             for non-shipping units. May also be supplied via
                             the EXCLUDE env var as a whitespace-separated list.
+    --assembly-threshold RULE
+                            (--per-assembly only, repeatable) A risk-tiered
+                            floor "GLOB = LINE[/BRANCH]" applied to each
+                            <package> whose NAME matches GLOB. The FIRST matching
+                            rule wins (declare the most specific first); an
+                            assembly matching no rule falls back to --threshold.
+                            Omitting BRANCH (e.g. "*.Host = 70") gates line only
+                            and skips the branch check — for host wiring you do
+                            not want to chase branch %. May also be supplied via
+                            the ASSEMBLY_THRESHOLDS env var as a newline-separated
+                            list ('#' comments and blank lines ignored).
     --output-dir DIR        Directory for output files (default: current directory)
     --baseline PATH         Accepted for backward compatibility; currently unused.
     --verbose               Enable verbose output
@@ -109,6 +139,15 @@ Examples:
 
     # Per-assembly gate over one merged report, excluding a non-shipping assembly
     $(basename "$0") --per-assembly ./coverage/merged.cobertura.xml --threshold 80 --exclude 'Bifrost.Scheduling.Testing'
+
+    # Per-assembly gate with risk-tiered floors (security/boundary held higher,
+    # host wiring line-only); the global --threshold is the fallback floor.
+    $(basename "$0") --per-assembly ./coverage/merged.cobertura.xml --threshold 80 \\
+        --assembly-threshold '*Identity*   = 85/75' \\
+        --assembly-threshold '*.Core       = 80/70' \\
+        --assembly-threshold '*.Host       = 70'
+    ASSEMBLY_THRESHOLDS=\$'*Identity* = 85/75\\n*.Core = 80/70' \\
+        $(basename "$0") --per-assembly ./coverage/merged.cobertura.xml --threshold 80
 EOF
     exit 1
 }
@@ -148,6 +187,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --exclude)
             EXCLUDE_GLOBS+=("$2")
+            shift 2
+            ;;
+        --assembly-threshold)
+            ASSEMBLY_THRESHOLD_RAW+=("$2")
             shift 2
             ;;
         --threshold)
@@ -262,26 +305,28 @@ extract_branch_coverage() {
     echo "N/A"
 }
 
-# Decide pass/fail for a single (line%, branch%) pair against THRESHOLD.
-# Used by per-project / per-assembly modes (which always gate line+branch) and
-# by the aggregate mode when --metrics line+branch is selected. A branch value
-# of "N/A" (no branch-rate in the report) skips the branch check. Echoes
-# "pass" or "fail"; returns 0/1 accordingly.
-check_thresholds() {
+# Decide pass/fail for a single (line%, branch%) pair against EXPLICIT line and
+# branch thresholds. An empty branch threshold — or a branch value of "N/A" (no
+# branch-rate in the report) — skips the branch check. Echoes "pass"/"fail" and
+# returns 0/1. This is the tiered-aware primitive; per-assembly mode passes a
+# rule's floor here, while check_thresholds wraps it with the global THRESHOLD.
+check_thresholds_against() {
     local line_pct="$1"
     local branch_pct="$2"
+    local line_thr="$3"
+    local branch_thr="$4"
 
     local line_int
     line_int=$(echo "$line_pct" | awk '{print int($1)}')
-    if [[ "$line_int" -lt "$THRESHOLD" ]]; then
+    if [[ "$line_int" -lt "$line_thr" ]]; then
         echo "fail"
         return 1
     fi
 
-    if [[ -n "$branch_pct" && "$branch_pct" != "N/A" ]]; then
+    if [[ -n "$branch_thr" && -n "$branch_pct" && "$branch_pct" != "N/A" ]]; then
         local branch_int
         branch_int=$(echo "$branch_pct" | awk '{print int($1)}')
-        if [[ "$branch_int" -lt "$THRESHOLD" ]]; then
+        if [[ "$branch_int" -lt "$branch_thr" ]]; then
             echo "fail"
             return 1
         fi
@@ -289,6 +334,14 @@ check_thresholds() {
 
     echo "pass"
     return 0
+}
+
+# Decide pass/fail for a single (line%, branch%) pair against the global
+# THRESHOLD (line + branch). Used by per-project mode and as the per-assembly
+# fallback for assemblies that match no tiered rule. A branch value of "N/A"
+# skips the branch check. Echoes "pass"/"fail"; returns 0/1.
+check_thresholds() {
+    check_thresholds_against "$1" "$2" "$THRESHOLD" "$THRESHOLD"
 }
 
 # True if the given filename matches any configured exclude glob.
@@ -302,6 +355,80 @@ is_excluded() {
         fi
     done
     return 1
+}
+
+# Parse one "GLOB = LINE[/BRANCH]" rule into the AT_* parallel arrays. Trims
+# surrounding whitespace, ignores blank lines and '#' comments, and tolerates
+# spaces around '=' and '/' (so "*Identity* = 85 / 75" is valid). A malformed
+# rule — missing '=', empty glob, or a non-numeric / out-of-range (>100)
+# percentage — is a hard error (exit 1) rather than a silently dropped floor.
+parse_assembly_threshold_rule() {
+    local rule="$1"
+    # Trim leading/trailing whitespace.
+    rule="${rule#"${rule%%[![:space:]]*}"}"
+    rule="${rule%"${rule##*[![:space:]]}"}"
+    [[ -z "$rule" ]] && return 0
+    [[ "$rule" == \#* ]] && return 0
+
+    if [[ "$rule" != *=* ]]; then
+        log_error "Invalid --assembly-threshold rule (expected 'GLOB = LINE[/BRANCH]'): $rule"
+        exit 1
+    fi
+
+    local glob="${rule%%=*}"
+    local spec="${rule#*=}"
+    # Trim whitespace around the glob and the spec.
+    glob="${glob#"${glob%%[![:space:]]*}"}"; glob="${glob%"${glob##*[![:space:]]}"}"
+    spec="${spec#"${spec%%[![:space:]]*}"}"; spec="${spec%"${spec##*[![:space:]]}"}"
+
+    if [[ -z "$glob" ]]; then
+        log_error "Invalid --assembly-threshold rule (empty glob): $rule"
+        exit 1
+    fi
+
+    local line_thr branch_thr
+    line_thr="${spec%%/*}"
+    if [[ "$spec" == */* ]]; then
+        branch_thr="${spec#*/}"
+    else
+        branch_thr=""
+    fi
+    # Strip any inner spaces (e.g. "85 / 75").
+    line_thr="${line_thr//[[:space:]]/}"
+    branch_thr="${branch_thr//[[:space:]]/}"
+
+    if ! [[ "$line_thr" =~ ^[0-9]+$ ]] || [[ "$line_thr" -gt 100 ]]; then
+        log_error "Invalid line threshold '$line_thr' in --assembly-threshold rule: $rule"
+        exit 1
+    fi
+    if [[ -n "$branch_thr" ]] && { ! [[ "$branch_thr" =~ ^[0-9]+$ ]] || [[ "$branch_thr" -gt 100 ]]; }; then
+        log_error "Invalid branch threshold '$branch_thr' in --assembly-threshold rule: $rule"
+        exit 1
+    fi
+
+    AT_GLOBS+=("$glob")
+    AT_LINE+=("$line_thr")
+    AT_BRANCH+=("$branch_thr")
+}
+
+# Resolve the effective (line, branch) floor for one assembly NAME against the
+# per-assembly threshold map. The FIRST matching glob wins (declare the most
+# specific rules first). Emits "LINE<TAB>BRANCH" where BRANCH is empty when the
+# matched rule omitted a branch floor (=> the branch check is skipped — the
+# "host wiring: don't chase branch %" case). An assembly matching no rule falls
+# back to the global THRESHOLD for both.
+effective_thresholds() {
+    local name="$1"
+    local n="${#AT_GLOBS[@]}"
+    local i
+    for (( i = 0; i < n; i++ )); do
+        # shellcheck disable=SC2053  # RHS is an intentional glob pattern
+        if [[ "$name" == ${AT_GLOBS[$i]} ]]; then
+            printf '%s\t%s\n' "${AT_LINE[$i]}" "${AT_BRANCH[$i]}"
+            return 0
+        fi
+    done
+    printf '%s\t%s\n' "$THRESHOLD" "$THRESHOLD"
 }
 
 # Extract per-package (assembly) rows from a single MERGED Cobertura report.
@@ -360,6 +487,17 @@ extract_assembly_rows() {
     fi
 }
 
+# Parse the raw per-assembly threshold rules now that the logging helpers are
+# defined (parse_assembly_threshold_rule exits 1 on a malformed rule). The map
+# is consumed only by --per-assembly mode; if rules were supplied in another
+# mode, warn rather than silently ignore them so the misconfiguration is visible.
+for _at_rule in "${ASSEMBLY_THRESHOLD_RAW[@]+"${ASSEMBLY_THRESHOLD_RAW[@]}"}"; do
+    parse_assembly_threshold_rule "$_at_rule"
+done
+if [[ "${#AT_GLOBS[@]}" -gt 0 && -z "$PER_ASSEMBLY_FILE" ]]; then
+    log_warn "Per-assembly threshold map supplied but mode is not --per-assembly; the map is ignored"
+fi
+
 # ---------------------------------------------------------------------------
 # Per-assembly mode: gate each <package> in a single MERGED Cobertura report.
 # Each <package name="AssemblyName" line-rate=".." branch-rate=".."> is one
@@ -384,21 +522,32 @@ if [[ -n "$PER_ASSEMBLY_FILE" ]]; then
 
         if is_excluded "$asm_name"; then
             log_info "Excluding ${asm_name} (matched exclude glob)"
-            ROWS+="| ${asm_name} | - | - | :fast_forward: Excluded |\n"
+            ROWS+="| ${asm_name} | - | - | - | :fast_forward: Excluded |\n"
             continue
         fi
 
         CONSIDERED=$((CONSIDERED + 1))
-        # '|| true' keeps `set -e` from aborting on a failing assembly — we
-        # branch on the echoed "pass"/"fail" string, not the exit status.
-        asm_result=$(check_thresholds "$asm_line" "$asm_branch") || true
+
+        # Resolve this assembly's effective floor: a matching tiered rule, else
+        # the global THRESHOLD. An empty branch floor means "don't gate branch"
+        # (rendered as "-" in the Threshold column).
+        IFS=$'\t' read -r asm_line_thr asm_branch_thr < <(effective_thresholds "$asm_name")
+        if [[ -n "$asm_branch_thr" ]]; then
+            asm_thr_label="${asm_line_thr}/${asm_branch_thr}"
+        else
+            asm_thr_label="${asm_line_thr}/-"
+        fi
+
+        # '|| true' keeps a failing assembly from aborting the loop — we branch
+        # on the echoed "pass"/"fail" string, not the exit status.
+        asm_result=$(check_thresholds_against "$asm_line" "$asm_branch" "$asm_line_thr" "$asm_branch_thr") || true
 
         if [[ "$asm_result" == "pass" ]]; then
-            log_info "PASS ${asm_name}: line ${asm_line}% / branch ${asm_branch}%"
-            ROWS+="| ${asm_name} | ${asm_line}% | ${asm_branch}% | :white_check_mark: Pass |\n"
+            log_info "PASS ${asm_name}: line ${asm_line}% / branch ${asm_branch}% (floor ${asm_thr_label})"
+            ROWS+="| ${asm_name} | ${asm_line}% | ${asm_branch}% | ${asm_thr_label} | :white_check_mark: Pass |\n"
         else
-            log_error "FAIL ${asm_name}: line ${asm_line}% / branch ${asm_branch}% (threshold ${THRESHOLD}%)"
-            ROWS+="| ${asm_name} | ${asm_line}% | ${asm_branch}% | :x: Fail |\n"
+            log_error "FAIL ${asm_name}: line ${asm_line}% / branch ${asm_branch}% (floor ${asm_thr_label})"
+            ROWS+="| ${asm_name} | ${asm_line}% | ${asm_branch}% | ${asm_thr_label} | :x: Fail |\n"
             OVERALL_STATUS="failing"
         fi
     done < <(extract_assembly_rows "$PER_ASSEMBLY_FILE")
@@ -412,12 +561,16 @@ if [[ -n "$PER_ASSEMBLY_FILE" ]]; then
     {
         echo "## :bar_chart: Per-Assembly Coverage Report"
         echo
-        echo "| Assembly | Line | Branch | Status |"
-        echo "|----------|------|--------|--------|"
+        echo "| Assembly | Line | Branch | Threshold | Status |"
+        echo "|----------|------|--------|-----------|--------|"
         echo -en "$ROWS"
         echo
         echo "---"
-        echo "<sub>Generated by coverage-gate.sh | Per-assembly gate | Threshold: ${THRESHOLD}% (line + branch)</sub>"
+        if [[ "${#AT_GLOBS[@]}" -gt 0 ]]; then
+            echo "<sub>Generated by coverage-gate.sh | Per-assembly gate | Tiered thresholds (Threshold column is line/branch; '-' = branch not gated); assemblies matching no rule use the global ${THRESHOLD}%</sub>"
+        else
+            echo "<sub>Generated by coverage-gate.sh | Per-assembly gate | Threshold: ${THRESHOLD}% (line + branch)</sub>"
+        fi
     } > "$PR_COMMENT_FILE"
 
     log_info "PR comment written to: $PR_COMMENT_FILE"

--- a/scripts/ci/coverage-gate.test.sh
+++ b/scripts/ci/coverage-gate.test.sh
@@ -341,6 +341,79 @@ run_gate_noxmllint 1 "task-18: --per-assembly (no xmllint) all-excluded fails (n
     --exclude 'Bifrost*'
 
 # ---------------------------------------------------------------------------
+# task-21 (issue #21) — per-assembly TIERED thresholds
+#
+# A risk-tiered floor map ("GLOB = LINE[/BRANCH]", repeatable / via
+# ASSEMBLY_THRESHOLDS) lets security/boundary assemblies be held higher than
+# host wiring. First matching rule wins; assemblies matching no rule fall back
+# to the global --threshold; an EMPTY map reproduces task-18 behavior exactly.
+# Fixtures reused: merged-multipackage-pass (all >= 80/80; Scheduling.Core
+# 0.92/0.84) and merged-multipackage (Bifrost.Core 0.93 line / 0.50 branch).
+# ---------------------------------------------------------------------------
+
+# RAISE: an all-passing report FAILS once a tiered rule lifts one assembly's
+# floor above its actual coverage (Scheduling.Core 0.92 line < a 95 floor).
+run_gate 1 "task-21: per-assembly tiered rule raising a floor fails an assembly above its actual coverage" -- \
+    --per-assembly "$DATA/merged-multipackage-pass.cobertura.xml" --threshold 80 \
+    --assembly-threshold '*Scheduling.Core = 95/90'
+
+# LOWER + fallback: the global-80 report FAILS on Bifrost.Core branch 0.50, but
+# a tiered rule lowering ONLY Bifrost.Core's branch floor to 40 flips it to PASS
+# while every other assembly is still gated at the global 80/80 fallback.
+run_gate 0 "task-21: per-assembly tiered rule lowering one assembly's branch floor passes; others use global fallback" -- \
+    --per-assembly "$DATA/merged-multipackage.cobertura.xml" --threshold 80 \
+    --assembly-threshold 'Bifrost.Core = 80/40'
+
+# Branch IS still gated under a tiered rule: a 60 branch floor on Bifrost.Core
+# (branch 0.50) FAILS — proves the lowered-floor pass above is real gating.
+run_gate 1 "task-21: per-assembly tiered branch floor still gates branch (Bifrost.Core 0.50 < 60)" -- \
+    --per-assembly "$DATA/merged-multipackage.cobertura.xml" --threshold 80 \
+    --assembly-threshold 'Bifrost.Core = 80/60'
+
+# LINE-ONLY rule (no BRANCH): host-wiring style "don't chase branch %". A rule
+# of "Bifrost.Core = 80" gates line only, so its 0.50 branch is ignored -> PASS.
+run_gate 0 "task-21: per-assembly line-only rule skips the branch check (host wiring)" -- \
+    --per-assembly "$DATA/merged-multipackage.cobertura.xml" --threshold 80 \
+    --assembly-threshold 'Bifrost.Core = 80'
+
+# FIRST-MATCH-WINS: a specific Bifrost.Core rule precedes a broad catch-all that
+# would otherwise fail it. Core passes on its specific 80/40; the catch-all
+# 99/99 fails the OTHER assemblies -> overall FAIL, proving order precedence.
+run_gate 1 "task-21: per-assembly first matching rule wins over a later catch-all" -- \
+    --per-assembly "$DATA/merged-multipackage.cobertura.xml" --threshold 80 \
+    --assembly-threshold 'Bifrost.Core = 80/40' \
+    --assembly-threshold '* = 99/99'
+
+# ENV VAR == FLAG: the same lowering rule supplied via ASSEMBLY_THRESHOLDS
+# (newline list, with a '#' comment + blank line to be ignored) -> PASS.
+ASSEMBLY_THRESHOLDS=$'# tiered floors\nBifrost.Core = 80/40\n' \
+    run_gate 0 "task-21: per-assembly honors the ASSEMBLY_THRESHOLDS env var (comments/blanks ignored)" -- \
+    --per-assembly "$DATA/merged-multipackage.cobertura.xml" --threshold 80
+
+# EMPTY MAP = PARITY: with no rules, the per-assembly verdict is unchanged from
+# task-18 (the all-passing report still PASSES) — the feature is purely additive.
+run_gate 0 "task-21: per-assembly with an empty threshold map is parity with task-18 (no drift)" -- \
+    --per-assembly "$DATA/merged-multipackage-pass.cobertura.xml" --threshold 80
+
+# MALFORMED RULE is a hard error, not a silently dropped floor.
+run_gate 1 "task-21: per-assembly malformed rule (no '=') fails fast" -- \
+    --per-assembly "$DATA/merged-multipackage-pass.cobertura.xml" --threshold 80 \
+    --assembly-threshold 'NoEqualsSign'
+
+run_gate 1 "task-21: per-assembly malformed rule (non-numeric percent) fails fast" -- \
+    --per-assembly "$DATA/merged-multipackage-pass.cobertura.xml" --threshold 80 \
+    --assembly-threshold 'Bifrost.Core = high/low'
+
+# grep/sed fallback (no xmllint) yields the same tiered verdict.
+run_gate_noxmllint 1 "task-21: per-assembly (no xmllint) tiered raise fails an assembly above its floor" -- \
+    --per-assembly "$DATA/merged-multipackage-pass.cobertura.xml" --threshold 80 \
+    --assembly-threshold '*Scheduling.Core = 95/90'
+
+run_gate_noxmllint 0 "task-21: per-assembly (no xmllint) tiered lower passes with global fallback" -- \
+    --per-assembly "$DATA/merged-multipackage.cobertura.xml" --threshold 80 \
+    --assembly-threshold 'Bifrost.Core = 80/40'
+
+# ---------------------------------------------------------------------------
 # DR-T2 — cross-language (TypeScript / vitest+istanbul) Cobertura
 #
 # The gate is generic Cobertura: it must read a vitest/istanbul `cobertura`


### PR DESCRIPTION
## What

Closes #21. Two **opt-in, additive** capabilities for risk-tiered coverage, both preserving current behavior at default inputs (the org parity contract):

### 1. Per-assembly tiered thresholds (coverage-gate chain)
`--per-assembly` mode gains an optional `glob = line[/branch]` floor map so security/boundary assemblies can be held higher than host wiring.

- **First matching rule wins** (declare most-specific first); assemblies matching no rule fall back to the global `coverage-threshold`.
- Omitting `BRANCH` (e.g. `*.Host = 70`) gates **line only** — the "don't chase branch % on host wiring" case.
- Malformed rules fail fast; the per-assembly PR comment gains a **Threshold** column.
- Supplied via repeatable `--assembly-threshold` / the `ASSEMBLY_THRESHOLDS` env, surfaced as the `assembly-thresholds` input on the `coverage-gate` action and `coverage-gate.yml`.

```yaml
gate-mode: per-assembly
assembly-thresholds: |
  *Identity*  = 85/75
  *Trading*   = 80/70
  *.Core      = 80/70
  *.Host      = 70      # line only
```

### 2. Generated-code exclusion (dotnet-build-test chain)
Opt-in `exclude-generated` input on the `dotnet-build-test` action + `build-and-test.yml`. When `true`, collection passes a committed default Microsoft code-coverage settings file (`--coverage-settings`) that drops generated code from the denominator by `GeneratedCodeAttribute` and `.g.cs`/`.g.i.cs`/`.Designer.cs` sources — even when a generator doesn't stamp `[ExcludeFromCodeCoverage]`.

The settings file re-declares the standard defaults it must preserve (`ExcludeFromCodeCoverage` honored, `Debugger*` excluded, `IncludeTestAssembly=False`) since a supplied file fully specifies `<CodeCoverage>`, and deliberately does **not** exclude `CompilerGeneratedAttribute` (which would drop async/await/yield/auto-props). Schema verified against [MS docs](https://learn.microsoft.com/dotnet/core/additional-tools/dotnet-coverage#settings).

## Design decisions

- **Both parts are opt-in (default off/empty).** The issue says "default" for part 2, but every enhancement in this repo (`--metrics line+branch`, `--per-assembly`, `test-filter`) is opt-in, and the codebase's parity norm forbids silently shifting strategos/basileus/DataFerry's coverage numbers. basileus#330 flips the inputs when it adopts the tiered gate org-wide.
- **Out of scope:** the issue's "host wiring: require a *boot test*" is a different gate (test-existence, not coverage); line-only rules are the coverage-gate's answer to "don't chase branch %."

## Verification

- **Gate script:** 45/45 cases in `coverage-gate.sh.test` (34 existing + **11 new** tiered cases: raise, lower+fallback, branch-still-gated, line-only, first-match-wins, env==flag, empty-map parity, malformed×2, no-xmllint×2). The existing aggregate/line **byte-parity** lock is untouched and green.
- **New CI gating:** `canary-coverage-gate.yml` now (a) runs the gate unit harness in CI (previously manual-only) and (b) proves the `assembly-thresholds` input fails a raised-floor assembly end-to-end through the action.
- **Settings file:** well-formed XML + correct exclude/preserve content asserted by a new fast `validate-coverage-settings` canary job.
- Local: all 6 edited/2 new YAML files parse; `bash -n` clean.

> Note: a full real-collector run of `exclude-generated=true` is not matrixed onto the bifrost canary because the action's hardcoded `coverage-reports` artifact upload collides under `upload-artifact@v4` when the action runs twice in one workflow run; that path is exercised when a consumer (bifrost/basileus) opts in.

## Release follow-up (maintainer)

`coverage-gate.yml` and `build-and-test.yml` pin their composite actions by `@<sha>`. On the next release, re-pin both to the SHA containing `assembly-thresholds` / `exclude-generated` (Dependabot/manual, same as every prior input addition) so wrapper consumers can use the new inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
