### PR TITLE
feat(ci): shared secretless Terraform deploy spine — composite action + deploy.yml (#13)

### DIFF
--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -1,0 +1,209 @@
+# =============================================================================
+# Canary: Terraform deploy spine (DR-1)
+# =============================================================================
+# CHAIN-SPECIFIC canary for the deploy spine — the `terraform-deploy` composite
+# action + its thin `deploy.yml` wrapper. NOT a shared/reusable file: it runs
+# only on pull requests to THIS repo (lvlup-sw/.github) that touch the deploy
+# chain, exercising the spine *as proposed on the PR head* before it can reach
+# any consumer.
+#
+# AUTH-FREE BY DESIGN. It runs against a provider-less local fixture
+# (scripts/ci/testdata/terraform-canary-fixture) with `-backend=false` and
+# `skip-login: true` — no azure/login, no cloud contact, no credentials. Do NOT
+# add cloud credentials to this canary: an org-wide reusable that self-tests
+# against a live tenant is a standing blast radius, and the fixture proves the
+# thing that actually needs proving (see below).
+#
+# What it checks:
+#   1. PLAN LEG   — deploy.yml's wiring/inputs resolve and a plan runs clean.
+#   2. APPLY LEG  — the fixture apply produces REAL local Terraform state, which
+#      is what makes (3) non-vacuous: outputs are read back from actual applied
+#      state rather than an empty map.
+#   3. OUTPUT FILTER (the security property) — the fixture declares BOTH a
+#      `sensitive = true` output and a plain one. The exposed map must have the
+#      sensitive key ABSENT *and* the plain key PRESENT.
+#
+#      BOTH HALVES ARE REQUIRED. Asserting only "sensitive is absent" would pass
+#      vacuously against an empty map — a filter that dropped everything, or an
+#      apply that produced nothing, would look identical to a working one. The
+#      assert job therefore fails an empty map outright.
+#
+#   4. PIN FRESHNESS — deploy.yml pins the action by SHA (DR-6), so the legs
+#      above test the PINNED action, not necessarily the PR head's source. This
+#      job fails if the pin does not resolve to the action source on this PR,
+#      which would make a green canary a lie about the code under review.
+#
+# ACCEPTED RESIDUAL (by design — do not "fix" it here): deploy.yml's gated
+# `apply` against real Azure is structurally verified only; this canary's apply
+# leg is auth-free. The spine those modes share IS live-certified via the
+# composite action by the T0 E2E harness. deploy.yml's own first live exercise
+# comes with its first standalone consumer (#56 T1 / #15).
+# =============================================================================
+
+name: Canary — Terraform Deploy Spine
+
+on:
+  pull_request:
+    paths:
+      - 'actions/terraform-deploy/**'
+      - '.github/workflows/deploy.yml'
+      - '.github/workflows/canary-deploy.yml'
+      - 'scripts/ci/testdata/terraform-canary-fixture/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FIXTURE_DIR: scripts/ci/testdata/terraform-canary-fixture
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # (1) PLAN LEG — proves the wrapper's wiring and inputs. No state, no cloud.
+  # ---------------------------------------------------------------------------
+  plan-leg:
+    name: Plan leg (fixture, auth-free)
+    # Local path => the PR head's deploy.yml is what runs (a canary must test
+    # the change, not @v1).
+    uses: ./.github/workflows/deploy.yml
+    permissions:
+      # deploy.yml requests id-token: write, and GitHub refuses to let a called
+      # workflow hold more permission than its caller — omitting this here is
+      # the exact `startup_failure` documented in deploy.yml's header. Granted
+      # even though skip-login means OIDC is never exercised.
+      id-token: write
+      contents: read
+    with:
+      working-directory: scripts/ci/testdata/terraform-canary-fixture
+      mode: plan
+      # Job-local state, no remote backend, no Azure.
+      backend-args: '-backend=false'
+      skip-login: true
+
+  # ---------------------------------------------------------------------------
+  # (2) APPLY LEG — the null apply produces real local state for the filter
+  # proof. Still auth-free: the fixture has no azurerm provider.
+  # ---------------------------------------------------------------------------
+  apply-leg:
+    name: Apply leg (fixture, auth-free)
+    uses: ./.github/workflows/deploy.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      working-directory: scripts/ci/testdata/terraform-canary-fixture
+      mode: apply
+      backend-args: '-backend=false'
+      skip-login: true
+
+  # ---------------------------------------------------------------------------
+  # (3) THE FILTER PROOF — non-vacuous by construction.
+  # ---------------------------------------------------------------------------
+  assert-output-filter:
+    name: Sensitive output dropped AND plain output kept
+    needs: apply-leg
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert the exposed output map
+        shell: bash
+        env:
+          # The map as it crossed the workflow_call output boundary — i.e.
+          # exactly what a consumer would receive.
+          TF_OUTPUTS: ${{ needs.apply-leg.outputs.terraform-outputs }}
+          PLAIN_KEY: plain_value
+          SENSITIVE_KEY: secret_value
+          EXPECTED_PLAIN: deploy-spine-canary-applied
+          SENSITIVE_LITERAL: spine-canary-sensitive-must-not-leak
+        run: |
+          set -euo pipefail
+          echo "deploy.yml exposed: ${TF_OUTPUTS}"
+
+          if ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$TF_OUTPUTS"; then
+            echo "::error::deploy.yml did not surface a JSON object (got: '${TF_OUTPUTS}')"
+            exit 1
+          fi
+
+          # --- NON-VACUITY GUARD ---------------------------------------------
+          # An empty map would satisfy the sensitive-absent check below while
+          # proving nothing at all. Fail it explicitly and first.
+          if [[ "$(jq -r 'length' <<<"$TF_OUTPUTS")" -eq 0 ]]; then
+            echo "::error::VACUOUS — the output map is EMPTY, so 'sensitive is absent' proves nothing."
+            echo "::error::Either the apply produced no state or the filter dropped everything."
+            exit 1
+          fi
+
+          # --- HALF 1: the plain output SURVIVED ------------------------------
+          if ! jq -e --arg k "$PLAIN_KEY" 'has($k)' >/dev/null <<<"$TF_OUTPUTS"; then
+            echo "::error::FILTER TOO AGGRESSIVE — non-sensitive '${PLAIN_KEY}' is missing from the exposed map"
+            exit 1
+          fi
+          actual="$(jq -r --arg k "$PLAIN_KEY" '.[$k]' <<<"$TF_OUTPUTS")"
+          if [[ "$actual" != "$EXPECTED_PLAIN" ]]; then
+            echo "::error::'${PLAIN_KEY}' is '${actual}', expected '${EXPECTED_PLAIN}' — the apply did not produce real state"
+            exit 1
+          fi
+          echo "OK — non-sensitive '${PLAIN_KEY}' present, read back from applied state"
+
+          # --- HALF 2: the sensitive output was DROPPED -----------------------
+          if jq -e --arg k "$SENSITIVE_KEY" 'has($k)' >/dev/null <<<"$TF_OUTPUTS"; then
+            echo "::error::LEAK — sensitive '${SENSITIVE_KEY}' crossed the output boundary"
+            exit 1
+          fi
+          echo "OK — sensitive '${SENSITIVE_KEY}' dropped by the filter"
+
+          # Defense in depth: the sensitive VALUE must appear nowhere, under any
+          # key (guards a filter that renames rather than drops).
+          if grep -qF "$SENSITIVE_LITERAL" <<<"$TF_OUTPUTS"; then
+            echo "::error::LEAK — the sensitive value is present in the exposed map"
+            exit 1
+          fi
+
+          echo "Canary OK: output filter is non-vacuously proven (sensitive ABSENT and plain PRESENT)."
+
+  # ---------------------------------------------------------------------------
+  # (4) PIN FRESHNESS — keeps the legs above honest.
+  #
+  # deploy.yml pins the composite action by SHA so consumers get a fully pinned
+  # graph (DR-6 / T13). The consequence is that the legs above exercise the
+  # action AT THAT PIN. If a PR edits the action but does not re-pin, the canary
+  # would silently certify the OLD action and go green over an untested change.
+  # ---------------------------------------------------------------------------
+  pin-freshness:
+    name: deploy.yml action pin resolves to this PR's action source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history — the pinned commit must be resolvable)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Assert the pinned SHA carries this PR's action.yml
+        shell: bash
+        run: |
+          set -euo pipefail
+          wf=.github/workflows/deploy.yml
+          action=actions/terraform-deploy/action.yml
+
+          pin="$(grep -oP 'lvlup-sw/\.github/actions/terraform-deploy@\K[0-9a-f]{40}' "$wf" || true)"
+          if [[ -z "$pin" ]]; then
+            echo "::error::$wf does not pin actions/terraform-deploy to a 40-char SHA (DR-6 requires a SHA pin)"
+            exit 1
+          fi
+          echo "deploy.yml pins terraform-deploy@$pin"
+
+          if ! git cat-file -e "${pin}^{commit}" 2>/dev/null; then
+            echo "::error::pinned commit $pin is not resolvable in this repository"
+            exit 1
+          fi
+
+          if ! git cat-file -p "${pin}:${action}" > /tmp/pinned-action.yml 2>/dev/null; then
+            echo "::error::pinned commit $pin does not contain $action"
+            exit 1
+          fi
+
+          if ! diff -u /tmp/pinned-action.yml "$action"; then
+            echo "::error::STALE PIN — $action changed on this PR but $wf still pins $pin."
+            echo "::error::The plan/apply legs would certify the OLD action. Re-pin deploy.yml to the commit carrying this action source."
+            exit 1
+          fi
+          echo "Pin is fresh: the legs exercise exactly this PR's action source."

--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -175,7 +175,11 @@ jobs:
       - name: Checkout (full history — the pinned commit must be resolvable)
         uses: actions/checkout@v4
         with:
+          # The pinned SHA is only reachable with the full history fetched.
           fetch-depth: 0
+          # This job reads local git objects; it never talks to the remote
+          # again, so the token has no reason to stay on disk.
+          persist-credentials: false
 
       - name: Assert the pinned SHA carries this PR's action.yml
         shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,200 @@
+# =============================================================================
+# Reusable Workflow: Terraform Deploy (secretless, federated OIDC)
+# =============================================================================
+# Runs a Terraform plan/apply/destroy against Azure as a single gateable job.
+#
+# This is a THIN JOB-SHAPED WRAPPER over the terraform-deploy composite action
+# (actions/terraform-deploy). All deploy logic lives in the action (single
+# source of truth, DR-1); this workflow only owns the workflow-level concerns
+# the action cannot: runs-on, the environment gate, `id-token: write`, and the
+# workflow_call signature.
+#
+# WORKFLOW OR ACTION? (they are not interchangeable here)
+#   - Use THIS WORKFLOW when the deploy is its own job — a standalone,
+#     environment-gated deployment. One `uses:` line.
+#   - Use the ACTION (actions/terraform-deploy) when you need apply/destroy as
+#     STEPS INSIDE YOUR OWN JOB — e.g. an ephemeral E2E harness whose Terraform
+#     state is job-local (-backend=false) and must stay on one runner, with
+#     assertions interleaved between apply and destroy. A workflow_call reusable
+#     cannot run as steps inside someone else's job, which is exactly why the
+#     mechanics live in the action.
+#   Both paths execute the same spine.
+#
+# ---------------------------------------------------------------------------
+# GOTCHA — MISSING `id-token: write` FAILS AT WORKFLOW STARTUP
+# ---------------------------------------------------------------------------
+# This workflow requests `id-token: write` (federated OIDC needs it to mint the
+# token). GitHub will NOT let a called workflow hold more permission than its
+# caller, and it validates that BEFORE running anything.
+#
+#   SYMPTOM: the run is marked `startup_failure` with NO jobs, no logs, and no
+#            annotation pointing at any step — it looks like the workflow file
+#            itself is broken. `gh run view <id>` shows an essentially empty run.
+#            The message, where it surfaces at all, reads like:
+#              "error parsing called workflow ... deploy.yml:
+#               the workflow is requesting 'id-token: write',
+#               but is only allowed 'id-token: none'"
+#
+#   CAUSE:   the CALLING job did not grant `id-token: write`. The default
+#            GITHUB_TOKEN permission set does not include id-token, so this bites
+#            every first-time caller.
+#
+#   FIX:     grant it on the calling job (permissions on a caller job apply to
+#            the reusable it calls):
+#              jobs:
+#                deploy:
+#                  permissions:
+#                    id-token: write   # REQUIRED — federated OIDC
+#                    contents: read
+#                  uses: lvlup-sw/.github/.github/workflows/deploy.yml@v1
+#
+# ---------------------------------------------------------------------------
+# SECURITY POSTURE
+# ---------------------------------------------------------------------------
+#   - SECRETLESS. Federated OIDC only; this workflow takes no secrets and there
+#     is no client-secret path anywhere in the chain. The OIDC ids are plain
+#     inputs — identifiers, not credentials — normally passed as repo
+#     `vars.AZURE_*`.
+#   - THE CALLER OWNS ENVIRONMENT PROTECTION. Pass `environment:` and configure
+#     the reviewer/branch rules on YOUR environment. A reusable workflow cannot
+#     impose a gate on its callers, so this file does not pretend to: it applies
+#     whatever environment you name, and an unnamed environment means no gate.
+#   - `terraform-outputs` is filtered to NON-SENSITIVE values by the action.
+#     Values crossing this workflow_call output boundary are NOT masked by
+#     GitHub, so never widen that filter.
+#
+# Usage:
+#   jobs:
+#     deploy:
+#       permissions:
+#         id-token: write        # REQUIRED — see the startup_failure gotcha above
+#         contents: read
+#       uses: lvlup-sw/.github/.github/workflows/deploy.yml@v1
+#       with:
+#         working-directory: infra/stamp
+#         mode: apply
+#         environment: production      # YOUR environment owns the reviewer gate
+#         client-id: ${{ vars.AZURE_CLIENT_ID }}
+#         tenant-id: ${{ vars.AZURE_TENANT_ID }}
+#         subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+# =============================================================================
+
+name: Terraform Deploy
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Directory containing the Terraform root module.'
+        required: false
+        type: string
+        default: '.'
+      mode:
+        description: 'Terraform operation: plan, apply, or destroy.'
+        required: true
+        type: string
+      environment:
+        description: >-
+          GitHub environment to run under. THE CALLER OWNS ITS PROTECTION RULES
+          (required reviewers, branch restrictions) — name an environment here to
+          gate the deploy. Empty (default) means no environment and no gate.
+        required: false
+        type: string
+        default: ''
+      terraform-version:
+        description: 'Terraform version for setup-terraform (exact version, constraint, or "latest").'
+        required: false
+        type: string
+        default: 'latest'
+      backend-args:
+        description: 'Extra whitespace-separated args for `terraform init` (e.g. -backend-config=..., or -backend=false for job-local state).'
+        required: false
+        type: string
+        default: ''
+      var-file:
+        description: 'Optional -var-file passed to plan/apply/destroy.'
+        required: false
+        type: string
+        default: ''
+      tf-vars:
+        description: 'JSON object of Terraform variables, expanded to TF_VAR_* env vars.'
+        required: false
+        type: string
+        default: '{}'
+      client-id:
+        description: 'Azure client id for federated OIDC (an identifier, not a secret — pass vars.AZURE_CLIENT_ID).'
+        required: false
+        type: string
+        default: ''
+      tenant-id:
+        description: 'Azure tenant id for federated OIDC (an identifier, not a secret — pass vars.AZURE_TENANT_ID).'
+        required: false
+        type: string
+        default: ''
+      subscription-id:
+        description: 'Azure subscription id for federated OIDC (an identifier, not a secret — pass vars.AZURE_SUBSCRIPTION_ID).'
+        required: false
+        type: string
+        default: ''
+      skip-login:
+        description: >-
+          When true, skip azure/login for auth-free fixture runs (canary use).
+          EVERY real deployment leaves this false.
+        required: false
+        type: boolean
+        default: false
+      runner:
+        description: 'GitHub Actions runner label.'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+    outputs:
+      terraform-outputs:
+        description: 'JSON map of the root module outputs, filtered to NON-SENSITIVE values only.'
+        value: ${{ jobs.deploy.outputs.terraform-outputs }}
+
+jobs:
+  deploy:
+    name: Terraform ${{ inputs.mode }}
+    runs-on: ${{ inputs.runner }}
+    # Applies the caller's environment (and therefore the caller's protection
+    # rules). An empty string means no environment.
+    environment: ${{ inputs.environment }}
+    permissions:
+      # REQUIRED for federated OIDC. A caller that does not also grant this
+      # fails at STARTUP — see the gotcha in the header.
+      id-token: write
+      contents: read
+    outputs:
+      terraform-outputs: ${{ steps.deploy.outputs.terraform-outputs }}
+    steps:
+      # Checks out the CALLER's repo at the caller's ref (github.repository/sha
+      # resolve to the caller in a reusable workflow) — i.e. the Terraform code
+      # being deployed. persist-credentials: false keeps the job's token off
+      # disk; Terraform never needs git creds.
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # All deploy logic lives in the terraform-deploy composite action (single
+      # source of truth, DR-1). The action is referenced by its full org-repo
+      # path so GitHub resolves it without a manual checkout, and pinned to a
+      # SHA rather than @main so a consumer pinning this workflow @v1 gets a
+      # fully SHA-pinned action graph (DR-6 / T13). Dependabot
+      # (.github/dependabot.yml) keeps this pin current; re-pin it to the
+      # release SHA when the next v1.x tag is cut.
+      - name: Terraform deploy
+        id: deploy
+        uses: lvlup-sw/.github/actions/terraform-deploy@27bfe259d15d257aa887a2a31887914e18cb9998 # feat/terraform-deploy-spine
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          mode: ${{ inputs.mode }}
+          terraform-version: ${{ inputs.terraform-version }}
+          backend-args: ${{ inputs.backend-args }}
+          var-file: ${{ inputs.var-file }}
+          tf-vars: ${{ inputs.tf-vars }}
+          client-id: ${{ inputs.client-id }}
+          tenant-id: ${{ inputs.tenant-id }}
+          subscription-id: ${{ inputs.subscription-id }}
+          skip-login: ${{ inputs.skip-login }}

--- a/actions/terraform-deploy/action.yml
+++ b/actions/terraform-deploy/action.yml
@@ -1,0 +1,257 @@
+# =============================================================================
+# Composite Action: terraform-deploy
+# =============================================================================
+# The org's shared, SECRETLESS Terraform deploy spine: federated GitHub OIDC ->
+# azure/login -> terraform init -> terraform plan|apply|destroy, exposing the
+# root module's NON-SENSITIVE outputs.
+#
+# This is the composable primitive behind the org's `deploy.yml` reusable
+# workflow (single source of truth): the workflow is a thin job-shaped preset
+# over this action.
+#
+# WHY AN ACTION AND NOT JUST A REUSABLE WORKFLOW (DR-1):
+#   The driving consumer is an ephemeral E2E harness that must run
+#   apply -> assert -> destroy as STEPS INSIDE A SINGLE JOB: its Terraform state
+#   is job-local (`-backend=false`) and never leaves the runner, so every mode
+#   has to land on the same box. A `workflow_call` reusable cannot run as steps
+#   inside someone else's job, so the mechanics live here and `deploy.yml`
+#   wraps this action for standalone (job-shaped) callers. Both paths execute
+#   the same spine.
+#
+# SECRETLESS — NON-NEGOTIABLE:
+#   Auth is federated OIDC only (`azure/login` + ARM_USE_OIDC=true). There is no
+#   ARM client-secret input, env var, or code path here, and there must never be
+#   one. The OIDC ids are ordinary inputs (repo `vars.AZURE_*`, not secrets) —
+#   they are identifiers, not credentials. The short-lived token is minted per
+#   run by GitHub, which is why the calling job needs `id-token: write`.
+#
+# OUTPUT FILTERING — THIS IS A SECURITY BOUNDARY:
+#   `terraform-outputs` is filtered to non-sensitive values only: every entry
+#   whose `.sensitive == true` is dropped before it leaves this action. A shared
+#   org action that echoed raw `terraform output` would turn every consumer's
+#   state into an org-wide leak channel — GitHub does NOT mask values crossing a
+#   job/workflow output boundary. Do not "simplify" the filter away.
+#
+# Modes (input -> terraform invocation):
+#   plan    -> terraform plan
+#   apply   -> terraform apply -auto-approve
+#   destroy -> terraform destroy -auto-approve
+#
+# The caller owns the checkout (this action never checks out code) and any
+# environment protection rules.
+# =============================================================================
+
+name: 'terraform-deploy'
+description: 'Secretless Terraform plan/apply/destroy against Azure via federated GitHub OIDC. Exposes non-sensitive terraform outputs.'
+
+inputs:
+  working-directory:
+    description: 'Directory containing the Terraform root module.'
+    required: false
+    default: '.'
+  mode:
+    description: 'Terraform operation: plan, apply, or destroy.'
+    required: true
+  terraform-version:
+    description: 'Terraform version for hashicorp/setup-terraform (exact version, constraint, or "latest").'
+    required: false
+    default: 'latest'
+  backend-args:
+    description: >-
+      Extra whitespace-separated args for `terraform init` — e.g.
+      "-backend-config=key=prod.tfstate" for a remote backend, or "-backend=false"
+      for job-local state that never leaves the runner (the E2E-harness posture).
+    required: false
+    default: ''
+  var-file:
+    description: 'Optional -var-file passed to plan/apply/destroy. Empty (default) omits the flag.'
+    required: false
+    default: ''
+  tf-vars:
+    description: >-
+      JSON object of Terraform variables, expanded to TF_VAR_* env vars. String
+      values are passed raw; every other type (number, bool, list, object) is
+      passed as compact JSON, which is what TF_VAR_ expects for complex types.
+    required: false
+    default: '{}'
+  client-id:
+    description: 'Azure AD application (client) id for federated OIDC. An identifier, not a secret — pass vars.AZURE_CLIENT_ID.'
+    required: false
+    default: ''
+  tenant-id:
+    description: 'Azure AD tenant id for federated OIDC. An identifier, not a secret — pass vars.AZURE_TENANT_ID.'
+    required: false
+    default: ''
+  subscription-id:
+    description: 'Azure subscription id for federated OIDC. An identifier, not a secret — pass vars.AZURE_SUBSCRIPTION_ID.'
+    required: false
+    default: ''
+  skip-login:
+    description: >-
+      When 'true', skip azure/login entirely for auth-free fixture runs (the
+      canary applies a provider-less fixture with no cloud contact). EVERY real
+      deployment leaves this at the default 'false' and logs in.
+    required: false
+    default: 'false'
+
+outputs:
+  terraform-outputs:
+    description: 'JSON map of the root module outputs, filtered to NON-SENSITIVE values only (sensitive entries are dropped).'
+    value: ${{ steps.tf-outputs.outputs.json }}
+
+runs:
+  using: 'composite'
+  steps:
+    # Fail fast on a bad mode BEFORE minting an OIDC token or touching Azure:
+    # an invalid mode is a caller typo, and it should not cost a cloud login.
+    - name: Validate mode
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+      run: |
+        set -euo pipefail
+        case "$MODE" in
+          plan|apply|destroy) echo "mode=$MODE" ;;
+          *)
+            echo "::error::Invalid mode '$MODE' (expected plan|apply|destroy)"
+            exit 1
+            ;;
+        esac
+
+    # Federated OIDC login. Skipped ONLY for auth-free fixture runs; every real
+    # mode authenticates here. Requires `id-token: write` on the calling job.
+    - name: Azure login (federated OIDC)
+      if: inputs.skip-login != 'true'
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+      with:
+        client-id: ${{ inputs.client-id }}
+        tenant-id: ${{ inputs.tenant-id }}
+        subscription-id: ${{ inputs.subscription-id }}
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      with:
+        terraform_version: ${{ inputs.terraform-version }}
+        # The wrapper rewrites terraform's stdout/exit handling; we parse
+        # `terraform output -json` directly, so it must stay off.
+        terraform_wrapper: false
+
+    # Expand the tf-vars JSON map to TF_VAR_* env vars for the steps below.
+    #
+    # Both halves of each GITHUB_ENV line are attacker-controlled in principle
+    # (a caller's JSON), so both are hardened: names must be plain identifiers,
+    # and values are written with a per-var random heredoc delimiter so a value
+    # containing an "EOF" line cannot forge an env var.
+    - name: Expand tf-vars to TF_VAR_* env
+      shell: bash
+      env:
+        TF_VARS: ${{ inputs.tf-vars }}
+      run: |
+        set -euo pipefail
+
+        if ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$TF_VARS"; then
+          echo "::error::tf-vars must be a JSON object (got: $(jq -r 'type' <<<"$TF_VARS" 2>/dev/null || echo 'invalid JSON'))"
+          exit 1
+        fi
+
+        # Materialize the key list BEFORE the loop rather than piping jq into it.
+        # A `while read < <(jq ...)` would swallow a jq failure — the loop would
+        # simply see no input and the step would report "0 variables" and exit 0,
+        # silently deploying with default variables. Assigning first lets
+        # `set -e` fail the step instead.
+        expected="$(jq -r 'length' <<<"$TF_VARS")"
+        keys="$(jq -r 'keys[]' <<<"$TF_VARS")"
+
+        count=0
+        while IFS= read -r name; do
+          [[ -z "$name" ]] && continue
+          if [[ ! "$name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            echo "::error::tf-vars key '$name' is not a valid Terraform variable name"
+            exit 1
+          fi
+          # Strings raw; every other type as compact JSON (TF_VAR_ semantics).
+          value="$(jq -r --arg k "$name" '.[$k] | if type == "string" then . else tojson end' <<<"$TF_VARS")"
+          delim="TF_VAR_EOF_${RANDOM}${RANDOM}${RANDOM}"
+          {
+            printf 'TF_VAR_%s<<%s\n' "$name" "$delim"
+            printf '%s\n' "$value"
+            printf '%s\n' "$delim"
+          } >> "$GITHUB_ENV"
+          # Name only — never echo the value.
+          echo "exported TF_VAR_$name"
+          count=$((count + 1))
+        done <<<"$keys"
+
+        # Belt-and-braces against the silent-drop failure mode above.
+        if [[ "$count" -ne "$expected" ]]; then
+          echo "::error::expanded $count TF_VAR_* but tf-vars declared $expected"
+          exit 1
+        fi
+        echo "expanded $count Terraform variable(s)"
+
+    - name: Terraform init
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        BACKEND_ARGS: ${{ inputs.backend-args }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC2206  # intentional word-splitting of the arg list
+        args=($BACKEND_ARGS)
+        echo "Running: terraform init -input=false ${args[*]}"
+        terraform init -input=false "${args[@]}"
+
+    # The deploy itself. ARM_USE_OIDC drives the azurerm provider's federated
+    # auth: it exchanges the GitHub-minted OIDC token (via the ACTIONS_ID_TOKEN_*
+    # env GitHub injects when id-token: write is granted) for an Azure token.
+    # No client secret is involved, here or anywhere in this action.
+    - name: Terraform ${{ inputs.mode }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        MODE: ${{ inputs.mode }}
+        VAR_FILE: ${{ inputs.var-file }}
+        ARM_USE_OIDC: 'true'
+        ARM_CLIENT_ID: ${{ inputs.client-id }}
+        ARM_TENANT_ID: ${{ inputs.tenant-id }}
+        ARM_SUBSCRIPTION_ID: ${{ inputs.subscription-id }}
+      run: |
+        set -euo pipefail
+
+        args=(-input=false)
+        [[ -n "$VAR_FILE" ]] && args+=(-var-file="$VAR_FILE")
+        # plan is read-only; apply/destroy are non-interactive in CI.
+        [[ "$MODE" != "plan" ]] && args+=(-auto-approve)
+
+        echo "Running: terraform $MODE ${args[*]}"
+        terraform "$MODE" "${args[@]}"
+
+    # Expose the root module's outputs, FILTERED to non-sensitive values.
+    #
+    # `terraform output -json` emits {name: {sensitive, type, value}}; the filter
+    # drops every sensitive entry, then unwraps the survivors to {name: value}.
+    # `terraform output` fails when no state exists yet (e.g. a plan-only run),
+    # which is not an error for this action — fall back to an empty map.
+    - name: Collect non-sensitive Terraform outputs
+      id: tf-outputs
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+
+        raw="$(terraform output -json 2>/dev/null || echo '{}')"
+        filtered="$(jq -c 'with_entries(select(.value.sensitive | not)) | map_values(.value)' <<<"$raw")"
+
+        # Report the shape only — the names/count are safe to log, and the
+        # dropped count is the audit trail for the filter actually firing.
+        total="$(jq -r 'length' <<<"$raw")"
+        kept="$(jq -r 'length' <<<"$filtered")"
+        echo "terraform outputs: $total total, $kept non-sensitive exposed, $((total - kept)) sensitive dropped"
+        echo "exposed keys: $(jq -rc 'keys' <<<"$filtered")"
+
+        delim="TF_OUT_EOF_${RANDOM}${RANDOM}${RANDOM}"
+        {
+          printf 'json<<%s\n' "$delim"
+          printf '%s\n' "$filtered"
+          printf '%s\n' "$delim"
+        } >> "$GITHUB_OUTPUT"

--- a/docs/guides/org-ci-consumer-guide.md
+++ b/docs/guides/org-ci-consumer-guide.md
@@ -4,10 +4,10 @@
 **Design / plan:** `docs/designs/2026-06-15-org-ci-rearchitecture.md`,
 `docs/plans/2026-06-15-org-ci-rearchitecture.md`.
 
-The org now ships CI as **composable building blocks**: four composite actions
-plus two thin preset reusable workflows built on top of them. This guide is for
-repos that consume them — how to pin a version, which building block to use, and
-how to opt into the stricter coverage gate.
+The org now ships CI as **composable building blocks**: composite actions, plus
+thin preset reusable workflows built on top of them (the table below is the
+catalog). This guide is for repos that consume them — how to pin a version, which
+building block to use, and how to opt into the stricter coverage gate.
 
 For the safe-bump and revert procedure, see
 `docs/runbooks/org-ci-parity-and-rollback.md`.
@@ -22,6 +22,8 @@ For the safe-bump and revert procedure, see
 | `coverage-gate` (composite action) | `actions/coverage-gate` | Run the shared gate script with full control over mode/metrics. |
 | `aot-smoke` (composite action, opt-in) | `actions/aot-smoke` | NativeAOT publish-and-run smoke. |
 | `benchmark-smoke` (composite action, opt-in) | `actions/benchmark-smoke` | BenchmarkDotNet `--job Dry` smoke. |
+| `deploy.yml` (reusable workflow) | `.github/workflows/deploy.yml` | Turnkey: a secretless, environment-gated Terraform `plan`/`apply`/`destroy` as its own job. |
+| `terraform-deploy` (composite action) | `actions/terraform-deploy` | Compose Terraform `plan`/`apply`/`destroy` as steps **inside your own job** — e.g. apply → assert → destroy on one runner. |
 
 **Workflow vs action:** use a **reusable workflow** when the org-standard job is
 all you need (one `uses:` line). Use the **composite actions** when you need to
@@ -164,6 +166,96 @@ unaffected.
     with:
       benchmark-project: src/MyApp.Benchmarks/MyApp.Benchmarks.csproj
 ```
+
+## Terraform deploy (`v1.6`+)
+
+The org's **secretless** Terraform deploy spine: federated GitHub OIDC →
+`azure/login` → `terraform init` → `plan` / `apply` / `destroy`.
+
+**There are no Azure secrets to configure, and you must not add any.** Auth is
+federated OIDC; there is no client-secret path anywhere in the chain. The OIDC
+ids are *identifiers, not credentials* — pass them as repo **variables**:
+
+```yaml
+jobs:
+  deploy:
+    permissions:
+      id-token: write        # REQUIRED — see the gotcha below
+      contents: read
+    uses: lvlup-sw/.github/.github/workflows/deploy.yml@v1
+    with:
+      working-directory: infra/stamp
+      mode: apply
+      environment: production        # YOUR environment owns the reviewer gate
+      client-id: ${{ vars.AZURE_CLIENT_ID }}
+      tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+```
+
+> **Gotcha — a missing `id-token: write` fails at workflow STARTUP.** GitHub
+> refuses to let a called workflow hold more permission than its caller, and
+> checks it *before* running anything. If your calling job omits
+> `id-token: write`, the run is marked `startup_failure` with **no jobs, no
+> logs, and no step annotation** — it looks like the workflow file is broken.
+> The real message, where it surfaces, is *"the workflow is requesting
+> 'id-token: write', but is only allowed 'id-token: none'"*. The default
+> `GITHUB_TOKEN` set has no `id-token`, so this bites every first-time caller.
+> Grant it on the **calling job**.
+
+**Workflow or action?** They are not interchangeable here:
+
+- **`deploy.yml` (workflow)** — the deploy is its own gateable job. One `uses:`.
+- **`terraform-deploy` (action)** — you need apply/destroy as **steps inside your
+  own job**: an ephemeral E2E harness whose Terraform state is job-local
+  (`-backend=false`) must keep every mode on one runner, with assertions
+  interleaved between apply and destroy. A `workflow_call` reusable cannot run as
+  steps inside your job. Both paths execute the same spine.
+
+```yaml
+# Action — apply → assert → destroy on a single runner, state never leaves it.
+steps:
+  - uses: actions/checkout@v4
+  - uses: lvlup-sw/.github/actions/terraform-deploy@v1
+    id: stamp
+    with:
+      working-directory: infra/stamp
+      mode: apply
+      backend-args: '-backend=false'
+      tf-vars: '{"location":"eastus","replicas":2}'
+      client-id: ${{ vars.AZURE_CLIENT_ID }}
+      tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+  - run: ./scripts/assert-stamp.sh
+    env:
+      STAMP: ${{ steps.stamp.outputs.terraform-outputs }}
+  - if: always()          # destroy even when the assertions fail
+    uses: lvlup-sw/.github/actions/terraform-deploy@v1
+    with:
+      working-directory: infra/stamp
+      mode: destroy
+      backend-args: '-backend=false'
+      client-id: ${{ vars.AZURE_CLIENT_ID }}
+      tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+```
+
+Notes:
+
+- **`terraform-outputs` is filtered to NON-SENSITIVE values.** Every entry whose
+  `.sensitive == true` is dropped before it leaves the action. GitHub does **not**
+  mask values crossing a job/workflow output boundary, so anything you expose
+  from a `sensitive` output would be readable org-wide. Mark secrets
+  `sensitive = true` in your root module and read them from Key Vault instead.
+- **You own your environment's protection rules.** A reusable workflow cannot
+  impose a gate on its callers: `deploy.yml` applies whatever `environment:` you
+  name, and naming none means **no gate**. Put required reviewers on the
+  environment in *your* repo.
+- **`tf-vars`** is a JSON object expanded to `TF_VAR_*`. Strings pass raw; every
+  other type (number, bool, list, object) passes as compact JSON.
+- **`backend-args`** goes to `terraform init` — `-backend-config=...` for a
+  remote backend, or `-backend=false` for job-local state.
+- `skip-login` exists only for auth-free fixture runs (the org canary). Leave it
+  `false` for every real deployment.
 
 ## Migration paths by repo
 

--- a/scripts/ci/testdata/terraform-canary-fixture/main.tf
+++ b/scripts/ci/testdata/terraform-canary-fixture/main.tf
@@ -1,0 +1,43 @@
+################################################################################
+# Terraform canary fixture — deploy-spine output filtering
+#
+# The fixture the `canary-deploy.yml` canary applies to prove the
+# `terraform-deploy` action's non-sensitive output filter. Deliberately NOT an
+# Azure config:
+#
+#   - NO `azurerm` provider, and no provider block at all. `terraform_data` is
+#     a Terraform built-in, so `terraform init -backend=false` downloads nothing
+#     and the apply makes zero network calls. The canary needs no cloud auth
+#     (skip-login: true) and cannot flake on the provider registry.
+#   - The apply produces REAL local state, which is what makes the filter proof
+#     non-vacuous: `terraform output` reads actual applied values rather than an
+#     empty map.
+#
+# The two outputs below are the whole point — one sensitive, one plain. The
+# canary asserts the sensitive key is ABSENT from the action's output map AND
+# the plain key is PRESENT. Both halves are required: asserting only "sensitive
+# is absent" would pass vacuously against an empty map.
+#
+# Changing the `sensitive` flag or the output names here will (by design) fail
+# the canary — that coupling is the kill-probe surface.
+################################################################################
+
+terraform {
+  # terraform_data is built in from 1.4 onward.
+  required_version = ">= 1.4"
+}
+
+resource "terraform_data" "canary" {
+  input = "deploy-spine-canary-applied"
+}
+
+output "plain_value" {
+  description = "Non-sensitive output. MUST survive the filter and be PRESENT in the action's output map."
+  value       = terraform_data.canary.output
+}
+
+output "secret_value" {
+  description = "Sensitive output. MUST be dropped by the filter and be ABSENT from the action's output map."
+  value       = "spine-canary-sensitive-must-not-leak"
+  sensitive   = true
+}


### PR DESCRIPTION
Ships the org's first **deploy mechanics**. #13's `deploy.yml` was deferred "until a service repo needs it" — that consumer has arrived (the T0 E2E harness in `hierophant`, which applies an Azure stamp into a dev tenant, asserts, and destroys it).

## Shape: why an action *and* a workflow

The T0 harness must run **apply → assert → destroy as steps inside a single job** — its Terraform state is job-local (`-backend=false`) and has to stay on one runner. A `workflow_call` reusable **cannot** run as steps inside someone else's job.

So the mechanics ship as a **composite action**, and `deploy.yml` is a thin job-shaped wrapper over that same action for standalone callers. Both paths execute one spine, which is what lets the harness genuinely *exercise* it (OIDC login, apply, destroy) rather than certify it on faith.

| Artifact | Path |
|---|---|
| composite action (the spine) | `actions/terraform-deploy/action.yml` |
| `workflow_call` wrapper | `.github/workflows/deploy.yml` |
| canary | `.github/workflows/canary-deploy.yml` |
| fixture | `scripts/ci/testdata/terraform-canary-fixture/main.tf` |
| catalog row + usage | `docs/guides/org-ci-consumer-guide.md` |

**Path note:** the task brief specified `.github/actions/terraform-deploy/`, but house style puts composite actions at repo-root `actions/<name>/` (six already live there, `dependabot.yml` scans `/actions/*`, and canaries resolve them via `./actions/<name>`). Followed house style; `.github/actions/` would have been invisible to Dependabot.

## Security posture

- **Secretless only.** Federated OIDC → `azure/login` → `ARM_USE_OIDC=true`. No client-secret input, env, or code path. `grep -ri 'ARM_CLIENT_SECRET'` over the diff returns **nothing**, and `gh secret list -R lvlup-sw/.github` is **empty** (the OIDC ids are repo *variables* — identifiers, not credentials).
- **Not an org-wide leak channel.** `terraform-outputs` drops every entry where `.sensitive == true` before it leaves the action. GitHub does **not** mask values crossing a job/workflow output boundary, so an unfiltered `terraform output` here would expose every consumer's state.
- **The caller owns environment protection.** A reusable cannot impose a gate on its callers; `deploy.yml` applies whatever `environment:` the caller names and documents that contract rather than pretending otherwise.
- **`id-token` startup_failure** documented in `deploy.yml`'s header: a caller that omits `id-token: write` gets a jobless, near-empty `startup_failure` that reads like a broken workflow file. Symptom is now written next to the cause.

## Canary: non-vacuous by construction

Two legs against a **provider-less** fixture (`terraform_data`, no `azurerm`), `-backend=false`, `skip-login: true` — no cloud auth at all:

- **plan leg** — proves the wrapper's wiring/inputs.
- **apply leg** — produces **real local state**, which is what makes the filter proof non-vacuous.

The fixture declares both a `sensitive = true` and a plain output. The assert job requires **both halves — sensitive ABSENT ∧ plain PRESENT** — and **fails an empty map outright**. Asserting only "sensitive is absent" would pass vacuously against an empty map; that trap is closed explicitly.

A fourth job guards **pin freshness**: `deploy.yml` pins the action by SHA (DR-6), so the legs test the action *at that pin*. A PR that edits the action without re-pinning would silently certify the old source and go green over an untested change. That case now fails.

## Accepted residual (by design — do not close it here)

`deploy.yml`'s gated-`apply` path against real Azure is **structurally verified only**; the canary's apply leg is auth-free. Its first live exercise comes with its first standalone consumer (**#56 T1 / #15**). The spine those modes share **is** live-certified via the composite action by the T0 harness, in a later task. Adding cloud credentials to the canary would make an org-wide reusable self-test against a live tenant — a standing blast radius — so it is deliberately not done.

## Verification

- **actionlint** — clean (exit 0) on both new workflows. (Repo-wide `actionlint` exits 1 on **pre-existing** findings in `format-check.yml`, `iteration-manager.yml`, `project-setup.yml`, `update-baseline.yml`, `deploy-runner-image.yml` — untouched by this PR.)
- **shellcheck** — clean on every `run:` block in the composite action (actionlint can't parse a composite `action.yml`, so its shell was linted directly).
- **Local** — fixture `fmt`/`validate`/`init -backend=false`/`apply` and the exact `jq` filter run locally: 2 outputs → 1 exposed, 1 sensitive dropped.
- **tf-vars expansion** unit-tested incl. two injection attempts: a value forging `TF_VAR_injected=pwned` stays contained inside the random-delimiter heredoc, and a malicious key name is rejected.

### Bug caught while testing (worth knowing)

The first cut used `while read ... < <(jq ...)`, which **bypasses `set -euo pipefail`**: when `jq` failed, the step printed "expanded 0 variables" and **exited 0** — on a runner that would have silently dropped every `TF_VAR_*` and deployed with default variables. Fixed by materializing the key list before the loop (so `set -e` fires) plus an expanded-vs-declared count check. Found because this build of `jq-1.7` lacks `keys_unsafe`; the silent-drop failure mode was the real find.

### Kill-probe

Performed on a throwaway branch (`probe/kill-deploy-canary`, PR #30 — closed, branch deleted; the runs persist). Sequence on one branch: **break → RED → break → RED → restore → GREEN.** A canary that stays green when the thing it guards is broken is worthless, so both halves of the assertion were probed independently.

**Probe A — flip the fixture's `sensitive = true` → `false`** (simulates the exact regression the filter exists to stop: a sensitive value leaking through).
→ 🔴 **RED** — [run 29559076710](https://github.com/lvlup-sw/.github/actions/runs/29559076710)

```
deploy.yml exposed: {"plain_value":"deploy-spine-canary-applied","secret_value":"spine-canary-sensitive-must-not-leak"}
OK — non-sensitive 'plain_value' present, read back from applied state
##[error]LEAK — sensitive 'secret_value' crossed the output boundary
```

**Probe B — remove the fixture's plain output**, so the filter yields `{}` (the vacuity trap: an empty map must **fail**, not silently satisfy "sensitive is absent").
→ 🔴 **RED** — [run 29559144249](https://github.com/lvlup-sw/.github/actions/runs/29559144249)

```
deploy.yml exposed: {}
##[error]VACUOUS — the output map is EMPTY, so 'sensitive is absent' proves nothing.
##[error]Either the apply produced no state or the filter dropped everything.
```

**Restore** the fixture → 🟢 **GREEN**, all 4 jobs — [run 29559196648](https://github.com/lvlup-sw/.github/actions/runs/29559196648)

In both probes only the **assert** job failed; the plan leg, apply leg, and pin-freshness stayed green — the canary fails for the right reason, in the right place, rather than going red on something incidental.

## Green canary (this PR)

[run 29559313157](https://github.com/lvlup-sw/.github/actions/runs/29559313157) — all 4 jobs green on the final commit. The apply leg is a real apply, not a no-op:

```
terraform_data.canary: Creation complete after 0s
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
terraform outputs: 2 total, 1 non-sensitive exposed, 1 sensitive dropped
exposed keys: ["plain_value"]
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)


## For whoever merges — one follow-up at the tag cut

`deploy.yml` pins the action to `27bfe259…`, a **commit on this branch**, because the action does not exist on `main` yet — a release SHA cannot be pinned before the release exists. The pin is real and resolvable (SHA-pinned graph per DR-6, and the commit survives the merge), so nothing breaks as-is.

**At the `v1.6` cut, re-pin it to the release SHA** and swap the trailing comment from the branch name to `# v1.6` — the same self-pin bump `dependabot.yml` already describes for the `lvlup-sw/.github/actions/...@<sha>` refs added in T13. The `pin-freshness` canary job enforces that the pin always resolves to the action source under review, so a forgotten re-pin cannot silently certify stale code.
